### PR TITLE
Add our logo as a distributor logo

### DIFF
--- a/Pop Overrides/48x48/apps/distributor-logo-popos.svg
+++ b/Pop Overrides/48x48/apps/distributor-logo-popos.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="Layer_1"
+   data-name="Layer 1"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64"
+   version="1.1"
+   sodipodi:docname="distributor-logo-popos.svg"
+   inkscape:version="0.92+devel unknown">
+  <metadata
+     id="metadata25">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Pop_icon</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs23" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     inkscape:document-rotation="0"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     id="namedview21"
+     showgrid="true"
+     fit-margin-top="5"
+     fit-margin-left="5"
+     fit-margin-right="5"
+     fit-margin-bottom="5"
+     inkscape:zoom="32"
+     inkscape:cx="30.068444"
+     inkscape:cy="20.484501"
+     inkscape:current-layer="g908"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid832"
+       originx="-92.999999"
+       originy="-93.000005" />
+  </sodipodi:namedview>
+  <title
+     id="title2">Pop_icon</title>
+  <g
+     id="g18"
+     transform="matrix(0.26427061,0,0,0.26427061,-92.999999,-93.264269)"
+     style="stroke-width:3.78399992">
+    <g
+       id="g918"
+       transform="matrix(0.216,0,0,0.216,370.832,371.616)">
+      <g
+         id="g26"
+         transform="matrix(1.1111111,0,0,1.1111111,-52.555562,-52.666673)">
+        <circle
+           id="circle4"
+           style="fill:#48b9c7;stroke-width:3.78400016"
+           r="473"
+           cy="474"
+           cx="473" />
+        <g
+           id="g908">
+          <rect
+             x="236.50003"
+             y="710.50012"
+             width="488.76666"
+             height="78.833305"
+             rx="39.416668"
+             style="fill:#ffffff;stroke-width:3.78399992"
+             id="rect6"
+             ry="39.416668" />
+          <g
+             id="g900">
+            <path
+               d="m 536,357 c -24,51 -64,92 -120,112 l 48,125 c 9,23 17,47 10,69 -7,22 -39,29 -62,5 -44,-47 -192,-343 -203,-365 -11,-22 -23,-40 -23,-62 1,-33 52,-67 77,-84 25,-17 74,-40 117,-41 43,-1 61,9 86,25 38,25 65,64 75,109 10,45 7,80 -5,105 M 423,301 c -9,-31 -28,-61 -53,-81 -5,-4 -11,-9 -18,-11 -46,-15 -26,62 -19,82 7,20 26,62 47,83 5,5 10,9 16,10 6,1 18,-5 23,-13 5,-8 6,-14 6,-22 a 128,128 0 0 0 -2,-48 z"
+               style="fill:#ffffff;stroke-width:14.31865597"
+               id="path10"
+               inkscape:connector-curvature="0" />
+            <g
+               id="g894">
+              <path
+                 d="m 625,664 c -2,9 -7,17 -15,22 -8,5 -27,5 -38,-4 -11,-9 -13,-24 -10,-36 3,-12 13,-25 27,-29 29,-9 42,23 36,47 z"
+                 style="fill:#ffffff;stroke-width:3.78399992"
+                 id="path12"
+                 inkscape:connector-curvature="0" />
+              <path
+                 d="m 607,573 c -18,-7 -12,-103 5,-220 5,-32 13,-48 22,-56 9,-8 36,-12 52,-9 a 90,90 0 0 1 49,24 c 12,11 13,23 9,38 -4,15 -18,47 -29,70 l -28,53 c -54,96 -65,106 -80,100 z"
+                 style="fill:#ffffff;stroke-width:3.78399992"
+                 id="path14"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This makes the following possible:

![screenshot from 2018-11-14 14-32-43](https://user-images.githubusercontent.com/4143535/48513843-2a396b80-e81a-11e8-9730-060385138e9b.png)

Closes #39