### PR TITLE
Remove files with spaces

### DIFF
--- a/Papirus/24x24/places/user-yellow-desktop (copy).svg
+++ b/Papirus/24x24/places/user-yellow-desktop (copy).svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" version="1.1">
- <rect style="opacity:0.2" width="20" height="18" x="2" y="3.5" rx="1" ry="1"/>
- <path style="fill:#e2b322" d="M 2,4.9 2,20 c 0,0.554 0.446,1 1,1 l 18,0 c 0.554,0 1,-0.446 1,-1 L 22,4.9 Z"/>
- <path style="fill:#4f3e0c" d="M 3,3 C 2.446,3 2,3.45 2,4 V 5 H 22 V 4 C 22,3.45 21.554,3 21,3 Z"/>
- <path style="fill:#4f3e0c" d="M 8,19 C 7.446,19 7,19.45 7,20 V 21 H 17 V 20 C 17,19.45 16.554,19 16,19 Z"/>
- <path style="opacity:0.1;fill:#ffffff" d="M 3,3 C 2.446,3 2,3.45 2,4 V 4.5 C 2,3.95 2.446,3.5 3,3.5 H 21 C 21.554,3.5 22,3.95 22,4.5 V 4 C 22,3.45 21.554,3 21,3 Z"/>
-</svg>


### PR DESCRIPTION
Removes a file which had a space in its filename. This caused installation errors for some users installing from git on some OSs.

Fixes #30 