### PR TITLE
Pager symbolic

### DIFF
--- a/Pop/scalable/actions/insert-image-symbolic.svg
+++ b/Pop/scalable/actions/insert-image-symbolic.svg
@@ -1,0 +1,48 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata90'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:title>Pop Symbolic Icon Theme</dc:title>
+        <cc:license rdf:resource='http://creativecommons.org/licenses/by-sa/4.0/'/>
+      </cc:Work>
+      <cc:License rdf:about='http://creativecommons.org/licenses/by-sa/4.0/'>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#Reproduction'/>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#Distribution'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#Notice'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#Attribution'/>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#DerivativeWorks'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#ShareAlike'/>
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <title id='title8473'>Pop Symbolic Icon Theme</title>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient6882' osb:paint='solid'>
+      <stop id='stop6884' offset='0' style='stop-color:#555555;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <filter id='filter7554' style='color-interpolation-filters:sRGB'>
+      <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
+    </filter>
+  </defs>
+  <g id='layer9' style='display:inline' transform='translate(-645.00021,-85)'/>
+  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-645.00021,-85)'/>
+  <g id='layer1' style='display:inline' transform='translate(-404.00001,-702)'/>
+  <g id='layer14' style='display:inline' transform='translate(-645.00021,-85)'/>
+  <g id='layer15' style='display:inline' transform='translate(-645.00021,-85)'/>
+  <g id='g71291' style='display:inline' transform='translate(-645.00021,-85)'/>
+  <g id='layer2' style='display:inline' transform='translate(-404.00001,-552)'/>
+  <g id='layer3' transform='translate(-404.00001,-812)'/>
+  <g id='layer12' style='display:inline' transform='translate(-645.00021,-85)'>
+    
+    <path d='m 650.0002,97.00003 3.00025,3.99995 2.99975,-3.99995 z' id='path6901-2' style='display:inline;fill:#4c5263;fill-opacity:1;stroke:none;enable-background:new'/>
+    <path d='m 649.5,85 c -1.6447,0 -3,1.355297 -3,3 v 5 c 0,1.644703 1.3553,3 3,3 h 7 c 1.6447,0 3,-1.355297 3,-3 v -5 c 0,-1.644703 -1.3553,-3 -3,-3 z m 0,2 h 7 c 0.5713,0 1,0.428703 1,1 v 5 c 0,0.571297 -0.4287,1 -1,1 h -7 c -0.5713,0 -1,-0.428703 -1,-1 v -5 c 0,-0.571297 0.4287,-1 1,-1 z' id='rect3239-4-4' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new'/>
+    <path d='m 649.50019,88 v 3 l 1.3125,-1.125 1.3125,1.125 2.1875,-1.875 2.1875,1.875 v -3 z' id='rect3241-4-7' style='display:inline;opacity:0.5;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1.62018526;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new'/>
+    <path d='m 653.00019,90 3.5,3 h -7 z' id='path3246-4-6' style='display:inline;opacity:1;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:0.81009263px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new'/>
+  </g>
+</svg>

--- a/Pop/scalable/actions/view-list-images-symbolic.svg
+++ b/Pop/scalable/actions/view-list-images-symbolic.svg
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata90'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:title>Pop Symbolic Icon Theme</dc:title>
+        <cc:license rdf:resource='http://creativecommons.org/licenses/by-sa/4.0/'/>
+      </cc:Work>
+      <cc:License rdf:about='http://creativecommons.org/licenses/by-sa/4.0/'>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#Reproduction'/>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#Distribution'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#Notice'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#Attribution'/>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#DerivativeWorks'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#ShareAlike'/>
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <title id='title8473'>Pop Symbolic Icon Theme</title>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient6882' osb:paint='solid'>
+      <stop id='stop6884' offset='0' style='stop-color:#555555;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <filter id='filter7554' style='color-interpolation-filters:sRGB'>
+      <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
+    </filter>
+  </defs>
+  <g id='layer9' style='display:inline' transform='translate(-605.0004,-24.99664)'/>
+  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-605.0004,-24.99664)'/>
+  <g id='layer1' style='display:inline' transform='translate(-364.0002,-641.99664)'/>
+  <g id='layer14' style='display:inline' transform='translate(-605.0004,-24.99664)'/>
+  <g id='layer15' style='display:inline' transform='translate(-605.0004,-24.99664)'/>
+  <g id='g71291' style='display:inline' transform='translate(-605.0004,-24.99664)'/>
+  <g id='layer2' style='display:inline' transform='translate(-364.0002,-491.99664)'/>
+  <g id='layer3' transform='translate(-364.0002,-751.99664)'/>
+  <g id='layer12' style='display:inline' transform='translate(-605.0004,-24.99664)'>
+    
+    <path d='m 610.0002,26.99958 -1,1 h -1 c -2,0 -2,2 -2,2 v 7 c 0,2 2,2 2,2 h 10 c 2,0 2,-2 2,-2 v -7 c 0,-2 -2,-2 -2,-2 h -1 l -1,-1 z m 3,3 c 1.65685,0 3,1.34315 3,3 0,1.65685 -1.34315,3 -3,3 -1.65685,0 -3,-1.34315 -3,-3 0,-1.65685 1.34315,-3 3,-3 z' id='path5683' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#4c5263;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;enable-background:accumulate'/>
+  </g>
+</svg>

--- a/Pop/scalable/actions/view-list-video-symbolic.svg
+++ b/Pop/scalable/actions/view-list-video-symbolic.svg
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16.003' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata90'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:title>Pop Symbolic Icon Theme</dc:title>
+        <cc:license rdf:resource='http://creativecommons.org/licenses/by-sa/4.0/'/>
+      </cc:Work>
+      <cc:License rdf:about='http://creativecommons.org/licenses/by-sa/4.0/'>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#Reproduction'/>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#Distribution'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#Notice'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#Attribution'/>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#DerivativeWorks'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#ShareAlike'/>
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <title id='title8473'>Pop Symbolic Icon Theme</title>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient6882' osb:paint='solid'>
+      <stop id='stop6884' offset='0' style='stop-color:#555555;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <filter id='filter7554' style='color-interpolation-filters:sRGB'>
+      <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
+    </filter>
+  </defs>
+  <g id='layer9' style='display:inline' transform='translate(-584.99717,-25)'/>
+  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-584.99717,-25)'/>
+  <g id='layer1' style='display:inline' transform='translate(-343.99697,-642)'/>
+  <g id='layer14' style='display:inline' transform='translate(-584.99717,-25)'/>
+  <g id='layer15' style='display:inline' transform='translate(-584.99717,-25)'/>
+  <g id='g71291' style='display:inline' transform='translate(-584.99717,-25)'/>
+  <g id='layer2' style='display:inline' transform='translate(-343.99697,-492)'/>
+  <g id='layer3' transform='translate(-343.99697,-752)'/>
+  <g id='layer12' style='display:inline' transform='translate(-584.99717,-25)'>
+    
+    <path d='m 587.0002,27.99958 h 9 c 1,0 1,1 1,1 v 8 c 0,1 -1,1 -1,1 h -9 c 0,0 -1,0 -1,-1 v -8 c 0,0 0,-1 1,-1 z m 13.99997,1.5 v 7.5 l -3.99997,-4 z' id='path5571' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate'/>
+  </g>
+</svg>

--- a/Pop/scalable/emblems/emblem-videos-symbolic.svg
+++ b/Pop/scalable/emblems/emblem-videos-symbolic.svg
@@ -1,0 +1,48 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata90'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:title>Pop Symbolic Icon Theme</dc:title>
+        <cc:license rdf:resource='http://creativecommons.org/licenses/by-sa/4.0/'/>
+      </cc:Work>
+      <cc:License rdf:about='http://creativecommons.org/licenses/by-sa/4.0/'>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#Reproduction'/>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#Distribution'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#Notice'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#Attribution'/>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#DerivativeWorks'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#ShareAlike'/>
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <title id='title8473'>Pop Symbolic Icon Theme</title>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient6882' osb:paint='solid'>
+      <stop id='stop6884' offset='0' style='stop-color:#555555;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <filter id='filter7554' style='color-interpolation-filters:sRGB'>
+      <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
+    </filter>
+  </defs>
+  <g id='layer9' style='display:inline' transform='translate(-845.00017,515)'/>
+  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-845.00017,515)'/>
+  <g id='layer1' style='display:inline' transform='translate(-603.99997,-102)'/>
+  <g id='layer14' style='display:inline' transform='translate(-845.00017,515)'/>
+  <g id='layer15' style='display:inline' transform='translate(-845.00017,515)'>
+    
+    <circle cx='849.00018' cy='-510' id='path4397-8' r='3' style='display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new'/>
+    <circle cx='856.00018' cy='-510' id='path4397-5-4' r='3' style='display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new'/>
+    <path d='m 857.0002,-506 3,-2 v 6 l -3,-2 z' id='path4432-8' style='display:inline;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new'/>
+    <rect height='6' id='rect4434-1' ry='2' style='display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new' width='11' x='846.00018' y='-508'/>
+  </g>
+  <g id='g71291' style='display:inline' transform='translate(-845.00017,515)'/>
+  <g id='layer2' style='display:inline' transform='translate(-603.99997,48)'/>
+  <g id='layer3' transform='translate(-603.99997,-212)'/>
+  <g id='layer12' style='display:inline' transform='translate(-845.00017,515)'/>
+</svg>

--- a/Pop/scalable/status/pager-checked-symbolic.svg
+++ b/Pop/scalable/status/pager-checked-symbolic.svg
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata90'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:title>Pop Symbolic Icon Theme</dc:title>
+        <cc:license rdf:resource='http://creativecommons.org/licenses/by-sa/4.0/'/>
+      </cc:Work>
+      <cc:License rdf:about='http://creativecommons.org/licenses/by-sa/4.0/'>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#Reproduction'/>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#Distribution'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#Notice'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#Attribution'/>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#DerivativeWorks'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#ShareAlike'/>
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <title id='title8473'>Pop Symbolic Icon Theme</title>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient6882' osb:paint='solid'>
+      <stop id='stop6884' offset='0' style='stop-color:#555555;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <filter id='filter7554' style='color-interpolation-filters:sRGB'>
+      <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
+    </filter>
+  </defs>
+  <g id='layer9' style='display:inline' transform='translate(-625.0002,435)'>
+    
+    <path d='m 633,-433.99609 c -3.86603,0 -7,3.13412 -7,7 0,3.86603 3.13397,7 7,7 3.86603,0 7,-3.13397 7,-7 0,-3.86588 -3.13397,-7 -7,-7 z' id='path3034' style='fill:#4c5263;fill-opacity:1;stroke:none'/>
+  </g>
+  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-625.0002,435)'/>
+  <g id='layer1' style='display:inline' transform='translate(-384,-182)'/>
+  <g id='layer14' style='display:inline' transform='translate(-625.0002,435)'/>
+  <g id='layer15' style='display:inline' transform='translate(-625.0002,435)'/>
+  <g id='g71291' style='display:inline' transform='translate(-625.0002,435)'/>
+  <g id='layer2' style='display:inline' transform='translate(-384,-32)'/>
+  <g id='layer3' transform='translate(-384,-292)'/>
+  <g id='layer12' style='display:inline' transform='translate(-625.0002,435)'/>
+</svg>

--- a/Pop/scalable/status/pager-unchecked-symbolic.svg
+++ b/Pop/scalable/status/pager-unchecked-symbolic.svg
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata90'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:title>Pop Symbolic Icon Theme</dc:title>
+        <cc:license rdf:resource='http://creativecommons.org/licenses/by-sa/4.0/'/>
+      </cc:Work>
+      <cc:License rdf:about='http://creativecommons.org/licenses/by-sa/4.0/'>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#Reproduction'/>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#Distribution'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#Notice'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#Attribution'/>
+        <cc:permits rdf:resource='http://creativecommons.org/ns#DerivativeWorks'/>
+        <cc:requires rdf:resource='http://creativecommons.org/ns#ShareAlike'/>
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <title id='title8473'>Pop Symbolic Icon Theme</title>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient6882' osb:paint='solid'>
+      <stop id='stop6884' offset='0' style='stop-color:#555555;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <filter id='filter7554' style='color-interpolation-filters:sRGB'>
+      <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
+    </filter>
+  </defs>
+  <g id='layer9' style='display:inline' transform='translate(-645.0002,435)'>
+    
+    <path d='m 653,-433.99609 c -3.86603,0 -7,3.13412 -7,7 0,3.86603 3.13397,7 7,7 3.86603,0 7,-3.13397 7,-7 0,-3.86588 -3.13397,-7 -7,-7 z M 653,-432 a 5,5 0 0 1 5,5 5,5 0 0 1 -5,5 5,5 0 0 1 -5,-5 5,5 0 0 1 5,-5 z' id='path3041' style='opacity:0.35;fill:#4c5263;fill-opacity:1;stroke:none'/>
+  </g>
+  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-645.0002,435)'/>
+  <g id='layer1' style='display:inline' transform='translate(-404,-182)'/>
+  <g id='layer14' style='display:inline' transform='translate(-645.0002,435)'/>
+  <g id='layer15' style='display:inline' transform='translate(-645.0002,435)'/>
+  <g id='g71291' style='display:inline' transform='translate(-645.0002,435)'/>
+  <g id='layer2' style='display:inline' transform='translate(-404,-32)'/>
+  <g id='layer3' transform='translate(-404,-292)'/>
+  <g id='layer12' style='display:inline' transform='translate(-645.0002,435)'/>
+</svg>

--- a/src/scalable/source-symbolic.svg
+++ b/src/scalable/source-symbolic.svg
@@ -28,15 +28,15 @@
      guidetolerance="10"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1044"
+     inkscape:window-width="2560"
+     inkscape:window-height="1370"
      id="namedview88"
      showgrid="true"
-     inkscape:zoom="5.6568541"
-     inkscape:cx="180.11654"
-     inkscape:cy="606.74635"
-     inkscape:window-x="2560"
-     inkscape:window-y="0"
+     inkscape:zoom="11.313708"
+     inkscape:cx="375.25253"
+     inkscape:cy="663.66922"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
      inkscape:window-maximized="1"
      inkscape:current-layer="layer9"
      showborder="true"
@@ -4130,6 +4130,45 @@
          y="-231"
          id="rect3039"
          style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+    </g>
+    <g
+       transform="translate(284.0002,-692)"
+       inkscape:label="pager-checked"
+       id="g3036"
+       style="display:inline;enable-background:new">
+      <rect
+         width="16"
+         height="16"
+         x="341"
+         y="257"
+         id="rect3032"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3034"
+         transform="translate(56.9998,-221)"
+         d="m 292,479.00391 c -3.86603,0 -7,3.13412 -7,7 0,3.86603 3.13397,7 7,7 3.86603,0 7,-3.13397 7,-7 0,-3.86588 -3.13397,-7 -7,-7 z"
+         style="fill:#4c5263;fill-opacity:1;stroke:none"
+         sodipodi:nodetypes="sssss" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       id="g3043"
+       inkscape:label="pager-unchecked"
+       transform="translate(304.0002,-692)">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:new"
+         id="rect3038"
+         y="257"
+         x="341"
+         height="16"
+         width="16" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3041"
+         transform="translate(36.9998,-221)"
+         d="m 312,479.00391 c -3.86603,0 -7,3.13412 -7,7 0,3.86603 3.13397,7 7,7 3.86603,0 7,-3.13397 7,-7 0,-3.86588 -3.13397,-7 -7,-7 z M 312,481 a 5,5 0 0 1 5,5 5,5 0 0 1 -5,5 5,5 0 0 1 -5,-5 5,5 0 0 1 5,-5 z"
+         style="opacity:0.35;fill:#4c5263;fill-opacity:1;stroke:none" />
     </g>
   </g>
   <g


### PR DESCRIPTION
Adds in missing pager-checked symbolic icons used in pop-shop (And adds a pager-unchecked icon if we want to switch to that for other screenshots).

Also adds in some icons which were previously missing. 

Fixes #38 