### PR TITLE
Update to more compliant menu icons

### DIFF
--- a/Pop/scalable/actions/open-menu-symbolic.svg
+++ b/Pop/scalable/actions/open-menu-symbolic.svg
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16.000017' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
   <metadata id='metadata90'>
     <rdf:RDF>
       <cc:Work rdf:about=''>
@@ -30,16 +30,16 @@
       <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
     </filter>
   </defs>
-  <g id='layer9' style='display:inline' transform='translate(-765.00019,95.003147)'/>
-  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-765.00019,95.003147)'/>
-  <g id='layer1' style='display:inline' transform='translate(-523.99999,-521.99685)'/>
-  <g id='layer14' style='display:inline' transform='translate(-765.00019,95.003147)'/>
-  <g id='layer15' style='display:inline' transform='translate(-765.00019,95.003147)'/>
-  <g id='g71291' style='display:inline' transform='translate(-765.00019,95.003147)'/>
-  <g id='layer2' style='display:inline' transform='translate(-523.99999,-371.99685)'/>
-  <g id='layer3' transform='translate(-523.99999,-631.99685)'/>
-  <g id='layer12' style='display:inline' transform='translate(-765.00019,95.003147)'>
-    <path d='m 774.99705,-93.00313 a 2,2 0 0 0 -2,-2 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 z m 0,6 a 2,2 0 0 0 -2,-2 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 z m 0,6 a 2,2 0 0 0 -2,-2 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 z' id='path6331' style='color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4c5263;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
+  <g id='layer9' style='display:inline' transform='translate(-765.0002,95.00333)'/>
+  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-765.0002,95.00333)'/>
+  <g id='layer1' style='display:inline' transform='translate(-524,-521.99667)'/>
+  <g id='layer14' style='display:inline' transform='translate(-765.0002,95.00333)'/>
+  <g id='layer15' style='display:inline' transform='translate(-765.0002,95.00333)'/>
+  <g id='g71291' style='display:inline' transform='translate(-765.0002,95.00333)'/>
+  <g id='layer2' style='display:inline' transform='translate(-524,-371.99667)'/>
+  <g id='layer3' transform='translate(-524,-631.99667)'/>
+  <g id='layer12' style='display:inline' transform='translate(-765.0002,95.00333)'>
     
+    <path d='m 777.99687,-91.00333 c 0,-0.554 -0.446,-1 -1,-1 h -8 c -0.554,0 -1,0.446 -1,1 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 z m 0,4 c 0,-0.554 -0.446,-1 -1,-1 h -8 c -0.554,0 -1,0.446 -1,1 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 z m 0,4 c 0,-0.554 -0.446,-1 -1,-1 h -8 c -0.554,0 -1,0.446 -1,1 0,0.554 0.446,1 1,1 h 8 c 0.554,0 1,-0.446 1,-1 z' id='path3047' style='fill:#4c5263;fill-opacity:1;stroke:none'/>
   </g>
 </svg>

--- a/Pop/scalable/actions/view-more-horizontal-symbolic.svg
+++ b/Pop/scalable/actions/view-more-horizontal-symbolic.svg
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16.000017' xmlns='http://www.w3.org/2000/svg'>
   <metadata id='metadata90'>
     <rdf:RDF>
       <cc:Work rdf:about=''>
@@ -30,16 +30,16 @@
       <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
     </filter>
   </defs>
-  <g id='layer9' style='display:inline' transform='translate(-685.00018,-4.9968569)'/>
-  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-685.00018,-4.9968569)'/>
+  <g id='layer9' style='display:inline' transform='translate(-685.00018,-4.9968613)'/>
+  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-685.00018,-4.9968613)'/>
   <g id='layer1' style='display:inline' transform='translate(-443.99998,-621.99686)'/>
-  <g id='layer14' style='display:inline' transform='translate(-685.00018,-4.9968569)'/>
-  <g id='layer15' style='display:inline' transform='translate(-685.00018,-4.9968569)'/>
-  <g id='g71291' style='display:inline' transform='translate(-685.00018,-4.9968569)'/>
+  <g id='layer14' style='display:inline' transform='translate(-685.00018,-4.9968613)'/>
+  <g id='layer15' style='display:inline' transform='translate(-685.00018,-4.9968613)'/>
+  <g id='g71291' style='display:inline' transform='translate(-685.00018,-4.9968613)'/>
   <g id='layer2' style='display:inline' transform='translate(-443.99998,-471.99686)'/>
   <g id='layer3' transform='translate(-443.99998,-731.99686)'/>
-  <g id='layer12' style='display:inline' transform='translate(-685.00018,-4.9968569)'>
+  <g id='layer12' style='display:inline' transform='translate(-685.00018,-4.9968613)'>
+    <path d='m 699.00018,14.99372 a 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 z m -6,0 a 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 z m -6,0 a 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 z' id='path3039' style='color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4c5263;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
     
-    <path d='m 697.99703,13.49642 c 0,0.82235 -0.67765,1.5 -1.5,1.5 -0.82235,0 -1.5,-0.67765 -1.5,-1.5 0,-0.82235 0.67765,-1.5 1.5,-1.5 0.82235,0 1.5,0.67765 1.5,1.5 z m -4,0 c 0,0.82235 -0.67765,1.5 -1.5,1.5 -0.82235,0 -1.5,-0.67765 -1.5,-1.5 0,-0.82235 0.67765,-1.5 1.5,-1.5 0.82235,0 1.5,0.67765 1.5,1.5 z m -4,0 c 0,0.82235 -0.67765,1.5 -1.5,1.5 -0.82235,0 -1.5,-0.67765 -1.5,-1.5 0,-0.82235 0.67765,-1.5 1.5,-1.5 0.82235,0 1.5,0.67765 1.5,1.5 z' id='path5743' style='color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4c5263;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new'/>
   </g>
 </svg>

--- a/Pop/scalable/actions/view-more-symbolic.svg
+++ b/Pop/scalable/actions/view-more-symbolic.svg
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16.000017' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
   <metadata id='metadata90'>
     <rdf:RDF>
       <cc:Work rdf:about=''>
@@ -30,16 +30,16 @@
       <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
     </filter>
   </defs>
-  <g id='layer9' style='display:inline' transform='translate(-665.00018,-4.9968491)'/>
-  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-665.00018,-4.9968491)'/>
-  <g id='layer1' style='display:inline' transform='translate(-423.99998,-621.99685)'/>
-  <g id='layer14' style='display:inline' transform='translate(-665.00018,-4.9968491)'/>
-  <g id='layer15' style='display:inline' transform='translate(-665.00018,-4.9968491)'/>
-  <g id='g71291' style='display:inline' transform='translate(-665.00018,-4.9968491)'/>
-  <g id='layer2' style='display:inline' transform='translate(-423.99998,-471.99685)'/>
-  <g id='layer3' transform='translate(-423.99998,-731.99685)'/>
-  <g id='layer12' style='display:inline' transform='translate(-665.00018,-4.9968491)'>
+  <g id='layer9' style='display:inline' transform='translate(-665.00019,-4.9968531)'/>
+  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-665.00019,-4.9968531)'/>
+  <g id='layer1' style='display:inline' transform='translate(-423.99999,-621.99685)'/>
+  <g id='layer14' style='display:inline' transform='translate(-665.00019,-4.9968531)'/>
+  <g id='layer15' style='display:inline' transform='translate(-665.00019,-4.9968531)'/>
+  <g id='g71291' style='display:inline' transform='translate(-665.00019,-4.9968531)'/>
+  <g id='layer2' style='display:inline' transform='translate(-423.99999,-471.99685)'/>
+  <g id='layer3' transform='translate(-423.99999,-731.99685)'/>
+  <g id='layer12' style='display:inline' transform='translate(-665.00019,-4.9968531)'>
+    <path d='m 674.99705,6.99687 a 2,2 0 0 0 -2,-2 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 z m 0,6 a 2,2 0 0 0 -2,-2 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 z m 0,6 a 2,2 0 0 0 -2,-2 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 z' id='path3032' style='color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4c5263;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
     
-    <path d='m 672.5002,7.999582 c -0.82235,0 -1.5,0.67765 -1.5,1.5 0,0.82235 0.67765,1.5 1.5,1.5 0.82235,0 1.5,-0.67765 1.5,-1.5 0,-0.82235 -0.67765,-1.5 -1.5,-1.5 z m 0,4 c -0.82235,0 -1.5,0.67765 -1.5,1.5 0,0.82235 0.67765,1.5 1.5,1.5 0.82235,0 1.5,-0.67765 1.5,-1.5 0,-0.82235 -0.67765,-1.5 -1.5,-1.5 z m 0,4 c -0.82235,0 -1.5,0.67765 -1.5,1.5 0,0.82235 0.67765,1.5 1.5,1.5 0.82235,0 1.5,-0.67765 1.5,-1.5 0,-0.82235 -0.67765,-1.5 -1.5,-1.5 z' id='path5435' style='color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4c5263;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new'/>
   </g>
 </svg>

--- a/src/scalable/source-symbolic.svg
+++ b/src/scalable/source-symbolic.svg
@@ -32,13 +32,13 @@
      inkscape:window-height="1370"
      id="namedview88"
      showgrid="true"
-     inkscape:zoom="11.313708"
-     inkscape:cx="375.25253"
-     inkscape:cy="663.66922"
+     inkscape:zoom="31.999999"
+     inkscape:cx="531.70803"
+     inkscape:cy="325.79048"
      inkscape:window-x="0"
      inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer9"
+     inkscape:current-layer="layer12"
      showborder="true"
      inkscape:snap-nodes="true"
      inkscape:snap-bbox="true"
@@ -4130,45 +4130,6 @@
          y="-231"
          id="rect3039"
          style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:new" />
-    </g>
-    <g
-       transform="translate(284.0002,-692)"
-       inkscape:label="pager-checked"
-       id="g3036"
-       style="display:inline;enable-background:new">
-      <rect
-         width="16"
-         height="16"
-         x="341"
-         y="257"
-         id="rect3032"
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:new" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3034"
-         transform="translate(56.9998,-221)"
-         d="m 292,479.00391 c -3.86603,0 -7,3.13412 -7,7 0,3.86603 3.13397,7 7,7 3.86603,0 7,-3.13397 7,-7 0,-3.86588 -3.13397,-7 -7,-7 z"
-         style="fill:#4c5263;fill-opacity:1;stroke:none"
-         sodipodi:nodetypes="sssss" />
-    </g>
-    <g
-       style="display:inline;enable-background:new"
-       id="g3043"
-       inkscape:label="pager-unchecked"
-       transform="translate(304.0002,-692)">
-      <rect
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:new"
-         id="rect3038"
-         y="257"
-         x="341"
-         height="16"
-         width="16" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3041"
-         transform="translate(36.9998,-221)"
-         d="m 312,479.00391 c -3.86603,0 -7,3.13412 -7,7 0,3.86603 3.13397,7 7,7 3.86603,0 7,-3.13397 7,-7 0,-3.86588 -3.13397,-7 -7,-7 z M 312,481 a 5,5 0 0 1 5,5 5,5 0 0 1 -5,5 5,5 0 0 1 -5,-5 5,5 0 0 1 5,-5 z"
-         style="opacity:0.35;fill:#4c5263;fill-opacity:1;stroke:none" />
     </g>
   </g>
   <g
@@ -10754,26 +10715,6 @@
     </g>
     <g
        style="display:inline;enable-background:new"
-       id="g6341"
-       inkscape:label="open-menu"
-       transform="rotate(90,781.00019,120.99686)">
-      <path
-         id="path6331"
-         transform="translate(241.0002,-497)"
-         d="m 326,624 a 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 z m 6,0 a 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 z m 6,0 a 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 z"
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4c5263;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
-      <rect
-         transform="scale(1,-1)"
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none"
-         id="rect6329"
-         width="16"
-         height="16"
-         x="565.00018"
-         y="-136.99686" />
-    </g>
-    <g
-       style="display:inline;enable-background:new"
        transform="matrix(-1,0,0,1,646.0004,44)"
        inkscape:label="media-view-subtitles"
        id="g8788">
@@ -13068,25 +13009,6 @@
          id="path5355" />
     </g>
     <g
-       style="display:inline;enable-background:new"
-       id="g8934-2"
-       inkscape:label="view-more"
-       transform="translate(248,-76)">
-      <rect
-         transform="rotate(-90)"
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none"
-         id="rect20588-8"
-         width="16"
-         height="16"
-         x="-96.996849"
-         y="417.00018" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4c5263;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new"
-         d="m 424.5002,83.999582 c -0.82235,0 -1.5,0.67765 -1.5,1.5 0,0.82235 0.67765,1.5 1.5,1.5 0.82235,0 1.5,-0.67765 1.5,-1.5 0,-0.82235 -0.67765,-1.5 -1.5,-1.5 z m 0,4 c -0.82235,0 -1.5,0.67765 -1.5,1.5 0,0.82235 0.67765,1.5 1.5,1.5 0.82235,0 1.5,-0.67765 1.5,-1.5 0,-0.82235 -0.67765,-1.5 -1.5,-1.5 z m 0,4 c -0.82235,0 -1.5,0.67765 -1.5,1.5 0,0.82235 0.67765,1.5 1.5,1.5 0.82235,0 1.5,-0.67765 1.5,-1.5 0,-0.82235 -0.67765,-1.5 -1.5,-1.5 z"
-         id="path5435"
-         inkscape:connector-curvature="0" />
-    </g>
-    <g
        style="display:inline;stroke:none;enable-background:new"
        transform="matrix(-1,0,0,1,642.00062,-862.00336)"
        inkscape:label="view-filter"
@@ -13324,25 +13246,6 @@
          x="42.000267"
          y="879.00525"
          ry="0.49990001" />
-    </g>
-    <g
-       style="display:inline;enable-background:new"
-       transform="matrix(0,-1,-1,0,781.99703,437.99704)"
-       inkscape:label="view-more-horizontal"
-       id="g5702-9">
-      <rect
-         y="417.00018"
-         x="-96.996849"
-         height="16"
-         width="16"
-         id="rect5708-3"
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none"
-         transform="rotate(-90)" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5743"
-         d="m 424.50062,84 c -0.82235,0 -1.5,0.67765 -1.5,1.5 0,0.82235 0.67765,1.5 1.5,1.5 0.82235,0 1.5,-0.67765 1.5,-1.5 0,-0.82235 -0.67765,-1.5 -1.5,-1.5 z m 0,4 c -0.82235,0 -1.5,0.67765 -1.5,1.5 0,0.82235 0.67765,1.5 1.5,1.5 0.82235,0 1.5,-0.67765 1.5,-1.5 0,-0.82235 -0.67765,-1.5 -1.5,-1.5 z m 0,4 c -0.82235,0 -1.5,0.67765 -1.5,1.5 0,0.82235 0.67765,1.5 1.5,1.5 0.82235,0 1.5,-0.67765 1.5,-1.5 0,-0.82235 -0.67765,-1.5 -1.5,-1.5 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4c5263;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
     </g>
     <g
        style="display:inline;enable-background:new"
@@ -13915,6 +13818,65 @@
          transform="scale(-1,1)"
          rx="0"
          ry="0.5" />
+    </g>
+    <g
+       transform="rotate(90,681.00019,120.99686)"
+       inkscape:label="view-more"
+       id="g3037"
+       style="display:inline;enable-background:new">
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4c5263;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 326,624 a 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 z m 6,0 a 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 z m 6,0 a 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 z"
+         transform="translate(241.0002,-497)"
+         id="path3032" />
+      <rect
+         y="-136.99686"
+         x="565.00018"
+         height="16"
+         width="16"
+         id="rect3035"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none"
+         transform="scale(1,-1)" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       id="g3043"
+       inkscape:label="view-more-horizontal"
+       transform="rotate(180,633.00019,70.996859)">
+      <path
+         id="path3039"
+         transform="translate(241.0002,-497)"
+         d="m 326,624 a 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 z m 6,0 a 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 z m 6,0 a 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4c5263;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <rect
+         transform="scale(1,-1)"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none"
+         id="rect3041"
+         width="16"
+         height="16"
+         x="565.00018"
+         y="-136.99686" />
+    </g>
+    <g
+       transform="rotate(90,662.00178,267.99845)"
+       id="g3049"
+       inkscape:label="open-menu"
+       style="display:inline;enable-background:new">
+      <rect
+         y="149.00003"
+         x="299"
+         height="16"
+         width="16"
+         id="rect3045"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none" />
+      <path
+         id="path3047"
+         transform="translate(-145,-118.99664)"
+         d="m 448,271 c -0.554,0 -1,0.446 -1,1 v 8 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 v -8 c 0,-0.554 -0.446,-1 -1,-1 z m 4,0 c -0.554,0 -1,0.446 -1,1 v 8 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 v -8 c 0,-0.554 -0.446,-1 -1,-1 z m 4,0 c -0.554,0 -1,0.446 -1,1 v 8 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 v -8 c 0,-0.554 -0.446,-1 -1,-1 z"
+         style="fill:#4c5263;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
This changes the menu icon metaphors to use vertical three dots for an overflow menu, and vertical three lines for an application/hamburger menu. This change makes the metaphors more consistent with upstream GNOME as well as other icon themes.

Before:
![Screenshot from 2019-06-07 11-06-35](https://user-images.githubusercontent.com/5883565/59121084-5a5e6e00-8914-11e9-9ebe-b926b1895b7d.png)

After:
![Screenshot from 2019-06-07 11-04-44](https://user-images.githubusercontent.com/5883565/59121101-634f3f80-8914-11e9-832b-9002fb301e58.png)
