### PR TITLE
fix: Add symlink from audio-subwoofer to audio-subwoofer-testing

### DIFF
--- a/Pop/128x128/devices/audio-subwoofer-testing.png
+++ b/Pop/128x128/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/Pop/128x128@2x/devices/audio-subwoofer-testing.png
+++ b/Pop/128x128@2x/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/Pop/16x16/devices/audio-subwoofer-testing.png
+++ b/Pop/16x16/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/Pop/16x16@2x/devices/audio-subwoofer-testing.png
+++ b/Pop/16x16@2x/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/Pop/24x24/devices/audio-subwoofer-testing.png
+++ b/Pop/24x24/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/Pop/24x24@2x/devices/audio-subwoofer-testing.png
+++ b/Pop/24x24@2x/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/Pop/256x256/devices/audio-subwoofer-testing.png
+++ b/Pop/256x256/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/Pop/256x256@2x/devices/audio-subwoofer-testing.png
+++ b/Pop/256x256@2x/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/Pop/32x32/devices/audio-subwoofer-testing.png
+++ b/Pop/32x32/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/Pop/32x32@2x/devices/audio-subwoofer-testing.png
+++ b/Pop/32x32@2x/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/Pop/48x48/devices/audio-subwoofer-testing.png
+++ b/Pop/48x48/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/Pop/48x48@2x/devices/audio-subwoofer-testing.png
+++ b/Pop/48x48@2x/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/Pop/64x64/devices/audio-subwoofer-testing.png
+++ b/Pop/64x64/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/Pop/64x64@2x/devices/audio-subwoofer-testing.png
+++ b/Pop/64x64@2x/devices/audio-subwoofer-testing.png
@@ -1,0 +1,1 @@
+audio-subwoofer.png

--- a/src/symlinks/bitmaps/devices.list
+++ b/src/symlinks/bitmaps/devices.list
@@ -1,4 +1,5 @@
 audio-speakers.png preferences-desktop-sound.png
+audio-subwoofer.png audio-subwoofer-testing.png
 bluetooth.png blueman-device.png
 camera-photo.png accessories-camera.png
 computer.png cs-screen.png


### PR DESCRIPTION
Adds a symlink from our `audio-subwoofer` icon to `audio-subwoofer-testing` to prevent the behavior in #56. We use a symlink so that if the base icon changes, the new file will also be updated.

Fixes #56