### PR TITLE
fix: Show simple scan icon

### DIFF
--- a/Pop/128x128/devices/org.gnome.SimpleScan.png
+++ b/Pop/128x128/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/Pop/128x128@2x/devices/org.gnome.SimpleScan.png
+++ b/Pop/128x128@2x/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/Pop/16x16/devices/org.gnome.SimpleScan.png
+++ b/Pop/16x16/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/Pop/16x16@2x/devices/org.gnome.SimpleScan.png
+++ b/Pop/16x16@2x/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/Pop/24x24/devices/org.gnome.SimpleScan.png
+++ b/Pop/24x24/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/Pop/24x24@2x/devices/org.gnome.SimpleScan.png
+++ b/Pop/24x24@2x/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/Pop/256x256/devices/org.gnome.SimpleScan.png
+++ b/Pop/256x256/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/Pop/256x256@2x/devices/org.gnome.SimpleScan.png
+++ b/Pop/256x256@2x/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/Pop/32x32/devices/org.gnome.SimpleScan.png
+++ b/Pop/32x32/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/Pop/32x32@2x/devices/org.gnome.SimpleScan.png
+++ b/Pop/32x32@2x/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/Pop/48x48/devices/org.gnome.SimpleScan.png
+++ b/Pop/48x48/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/Pop/48x48@2x/devices/org.gnome.SimpleScan.png
+++ b/Pop/48x48@2x/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/Pop/64x64/devices/org.gnome.SimpleScan.png
+++ b/Pop/64x64/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/Pop/64x64@2x/devices/org.gnome.SimpleScan.png
+++ b/Pop/64x64@2x/devices/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+scanner.png

--- a/src/symlinks/bitmaps/devices.list
+++ b/src/symlinks/bitmaps/devices.list
@@ -36,3 +36,4 @@ printer.png cs-printer.png
 printer.png cups.png
 printer.png gnome-dev-printer.png
 printer.png preferences-desktop-printer.png
+scanner.png org.gnome.SimpleScan.png


### PR DESCRIPTION
Install an Icon for simple scan

Fixes #54 