### PR TITLE
Fix: Missing Icons Pop!_Shop

### DIFF
--- a/Pop/scalable/status/sync-synchronizing.svg
+++ b/Pop/scalable/status/sync-synchronizing.svg
@@ -1,0 +1,1 @@
+../emblems/emblem-synchronizing-symbolic.svg


### PR DESCRIPTION
Fix is for pop shop showing missing icon while checking for updates. It uses an existing emblem for now.

This pull request is mainly to discuss if we should keep same emblem or something else.

The name of icon is coming in from an Alert View in Pop!_Shop repository source [here](https://github.com/pop-os/shop/blob/master/src/Widgets/AbstractAppList.vala#L47).

## Before:
![before-icon-fix](https://user-images.githubusercontent.com/5254217/87874272-2219d200-c9e6-11ea-935c-4e69d599b3ab.png)

## After:
![after-icon-fix](https://user-images.githubusercontent.com/5254217/87874277-28a84980-c9e6-11ea-94fe-1d61db7ab706.png)
