### PR TITLE
Position speakers

### DIFF
--- a/Pop/scalable/devices/audio-speaker-center-back-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-center-back-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-425 135)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='rotate(-90 492 -346)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:.5;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-center-back-testing-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-center-back-testing-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-485 135)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='rotate(-90 522 -376)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:1;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-center-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-center-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-425 175)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='rotate(90 234 -206)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:.5;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-center-testing-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-center-testing-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-485 175)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='rotate(90 264 -176)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:1;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-left-back-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-left-back-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-405 135)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(140 278)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M268.062-408.727a.995.995 0 0 0-.261.545l-.53 4.42-.708.707-.707.707a.998.998 0 0 0 0 1.414l2.828 2.828a.998.998 0 0 0 1.415 0l.707-.707.707-.707 4.42-.53c.63-.076 1.237-.884.53-1.591l-3.536-3.536-3.535-3.535c-.487-.486-1.02-.352-1.33-.015z' style='opacity:1;fill:#4c5263;fill-opacity:1'/>
+            <path d='m271.955-407.563.972-1.856c2.121.707 3.536 2.121 4.243 4.242l-1.856.973c-.708-2.122-1.238-2.652-3.36-3.36zM272.883-410.878l.751-2.077c3.536.707 6.364 3.536 7.071 7.071l-2.077.751c-.707-3.535-2.21-5.038-5.745-5.745z' style='opacity:.5;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-left-back-testing-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-left-back-testing-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-465 135)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(200 278)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M268.062-408.727a.995.995 0 0 0-.261.545l-.53 4.42-.708.707-.707.707a.998.998 0 0 0 0 1.414l2.828 2.828a.998.998 0 0 0 1.415 0l.707-.707.707-.707 4.42-.53c.63-.076 1.237-.884.53-1.591l-3.536-3.536-3.535-3.535c-.487-.486-1.02-.352-1.33-.015z' style='opacity:1;fill:#4c5263;fill-opacity:1'/>
+            <path d='m271.955-407.563.972-1.856c2.121.707 3.536 2.121 4.243 4.242l-1.856.973c-.708-2.122-1.238-2.652-3.36-3.36zM272.883-410.878l.751-2.077c3.536.707 6.364 3.536 7.071 7.071l-2.077.751c-.707-3.535-2.21-5.038-5.745-5.745z' style='opacity:1;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-left-side-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-left-side-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-405 155)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(140 258)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:.5;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-left-side-testing-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-left-side-testing-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-465 155)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(200 258)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:1;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-left-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-left-symbolic.svg
@@ -1,0 +1,15 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-405 175)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(140 238)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M276.478-409.689a.995.995 0 0 0-.545-.26l-4.42-.531-.707-.707-.707-.707a.998.998 0 0 0-1.414 0l-2.829 2.828a.998.998 0 0 0 0 1.414l.707.708.707.707.53 4.419c.077.631.885 1.237 1.592.53l3.535-3.535 3.536-3.536c.486-.486.352-1.019.015-1.33z' style='opacity:1;fill:#4c5263;fill-opacity:1'/>
+            <path d='m275.314-405.795 1.856.972c-.707 2.121-2.121 3.535-4.243 4.242l-.972-1.856c2.121-.707 2.652-1.237 3.359-3.358z' style='opacity:.5;fill:#4c5263'/>
+            <path d='m278.628-404.867 2.077.75c-.707 3.536-3.535 6.365-7.07 7.072l-.752-2.077c3.536-.707 5.038-2.21 5.745-5.745z' style='opacity:.5;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-left-testing-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-left-testing-symbolic.svg
@@ -1,0 +1,15 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-465 175)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(200 238)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M276.478-409.689a.995.995 0 0 0-.545-.26l-4.42-.531-.707-.707-.707-.707a.998.998 0 0 0-1.414 0l-2.829 2.828a.998.998 0 0 0 0 1.414l.707.708.707.707.53 4.419c.077.631.885 1.237 1.592.53l3.535-3.535 3.536-3.536c.486-.486.352-1.019.015-1.33z' style='opacity:1;fill:#4c5263;fill-opacity:1'/>
+            <path d='m275.314-405.795 1.856.972c-.707 2.121-2.121 3.535-4.243 4.242l-.972-1.856c2.121-.707 2.652-1.237 3.359-3.358z' style='opacity:1;fill:#4c5263'/>
+            <path d='m278.628-404.867 2.077.75c-.707 3.536-3.535 6.365-7.07 7.072l-.752-2.077c3.536-.707 5.038-2.21 5.745-5.745z' style='opacity:1;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-right-back-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-right-back-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-445 135)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(180 278)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M269.406-400.152a.995.995 0 0 0 .546.26l4.42.531.706.707.707.707a.998.998 0 0 0 1.415 0l2.828-2.828a.998.998 0 0 0 0-1.414l-.707-.707-.707-.708-.53-4.419c-.076-.631-.884-1.237-1.592-.53l-3.535 3.535-3.536 3.536c-.486.486-.351 1.019-.015 1.33z' style='opacity:1;fill:#4c5263;fill-opacity:1'/>
+            <path d='m270.57-404.045-1.856-.973c.707-2.121 2.122-3.535 4.243-4.242l.972 1.856c-2.121.707-2.651 1.237-3.359 3.359zM267.256-404.974l-2.077-.75c.707-3.536 3.535-6.365 7.07-7.072l.752 2.077c-3.535.707-5.038 2.21-5.745 5.745z' style='opacity:.5;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-right-back-testing-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-right-back-testing-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-505 135)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(240 278)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M269.406-400.152a.995.995 0 0 0 .546.26l4.42.531.706.707.707.707a.998.998 0 0 0 1.415 0l2.828-2.828a.998.998 0 0 0 0-1.414l-.707-.707-.707-.708-.53-4.419c-.076-.631-.884-1.237-1.592-.53l-3.535 3.535-3.536 3.536c-.486.486-.351 1.019-.015 1.33z' style='opacity:1;fill:#4c5263;fill-opacity:1'/>
+            <path d='m270.57-404.045-1.856-.973c.707-2.121 2.122-3.535 4.243-4.242l.972 1.856c-2.121.707-2.651 1.237-3.359 3.359zM267.256-404.974l-2.077-.75c.707-3.536 3.535-6.365 7.07-7.072l.752 2.077c-3.535.707-5.038 2.21-5.745 5.745z' style='opacity:1;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-right-side-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-right-side-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-445 155)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='rotate(180 363 -276)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:.5;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-right-side-testing-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-right-side-testing-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-505 155)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='rotate(180 393 -276)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:1;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-right-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-right-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-445 175)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(180 238)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M277.823-401.431a.995.995 0 0 0 .26-.546l.531-4.42.707-.706.707-.707a.998.998 0 0 0 0-1.415l-2.828-2.828a.998.998 0 0 0-1.414 0l-.708.707-.707.707-4.42.53c-.63.076-1.237.884-.53 1.592l3.536 3.535 3.536 3.536c.486.486 1.019.352 1.33.015z' style='opacity:1;fill:#4c5263;fill-opacity:1'/>
+            <path d='m273.93-402.595-.973 1.856c-2.121-.707-3.535-2.122-4.243-4.243l1.857-.972c.707 2.121 1.237 2.652 3.358 3.359zM273.001-399.28l-.751 2.076c-3.535-.707-6.364-3.535-7.071-7.07l2.077-.752c.707 3.535 2.21 5.038 5.745 5.745z' style='opacity:.5;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-right-testing-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-right-testing-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-505 175)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(240 238)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M277.823-401.431a.995.995 0 0 0 .26-.546l.531-4.42.707-.706.707-.707a.998.998 0 0 0 0-1.415l-2.828-2.828a.998.998 0 0 0-1.414 0l-.708.707-.707.707-4.42.53c-.63.076-1.237.884-.53 1.592l3.536 3.535 3.536 3.536c.486.486 1.019.352 1.33.015z' style='opacity:1;fill:#4c5263;fill-opacity:1'/>
+            <path d='m273.93-402.595-.973 1.856c-2.121-.707-3.535-2.122-4.243-4.243l1.857-.972c.707 2.121 1.237 2.652 3.358 3.359zM273.001-399.28l-.751 2.076c-3.535-.707-6.364-3.535-7.071-7.07l2.077-.752c.707 3.535 2.21 5.038 5.745 5.745z' style='opacity:1;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-385 175)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(120 238)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:.5;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-speaker-testing-symbolic.svg
+++ b/Pop/scalable/devices/audio-speaker-testing-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-385 155)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(120 258)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:1;fill:#4c5263'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-subwoofer-symbolic.svg
+++ b/Pop/scalable/devices/audio-subwoofer-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-465 175)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(200 238)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <rect height='6' ry='3' style='opacity:.35;fill:#4c5263;fill-opacity:1;stroke:none' width='6' x='270' y='-405'/>
+            <path d='M228 552c-1.108 0-2 .892-2 2v12c0 1.108.892 2 2 2h8c1.108 0 2-.892 2-2v-12c0-1.108-.892-2-2-2zm1 2h6c.554 0 1 .446 1 1v2c0 .554-.446 1-1 1h-6c-.554 0-1-.446-1-1v-2c0-.554.446-1 1-1zm-1 5a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1zm8 0a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1zm-4 1c1.662 0 3 1.338 3 3s-1.338 3-3 3-3-1.338-3-3 1.338-3 3-3zm0 2c-.554 0-1 .446-1 1s.446 1 1 1 1-.446 1-1-.446-1-1-1zm-4 3a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1zm8 0a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1z' style='opacity:1;fill:#4c5263;fill-opacity:1;stroke:none' transform='translate(41 -965)'/>
+        </g>
+    </g>
+</svg>

--- a/Pop/scalable/devices/audio-subwoofer-testing-symbolic.svg
+++ b/Pop/scalable/devices/audio-subwoofer-testing-symbolic.svg
@@ -1,0 +1,14 @@
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-525 175)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(260 238)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <rect height='6' ry='3' style='opacity:.35;fill:#4caf50;fill-opacity:1;stroke:none' width='6' x='270' y='-405'/>
+            <path d='M228 552c-1.108 0-2 .892-2 2v12c0 1.108.892 2 2 2h8c1.108 0 2-.892 2-2v-12c0-1.108-.892-2-2-2zm1 2h6c.554 0 1 .446 1 1v2c0 .554-.446 1-1 1h-6c-.554 0-1-.446-1-1v-2c0-.554.446-1 1-1zm-1 5a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1zm8 0a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1zm-4 1c1.662 0 3 1.338 3 3s-1.338 3-3 3-3-1.338-3-3 1.338-3 3-3zm0 2c-.554 0-1 .446-1 1s.446 1 1 1 1-.446 1-1-.446-1-1-1zm-4 3a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1zm8 0a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1z' style='opacity:1;fill:#4c5263;fill-opacity:1;stroke:none' transform='translate(41 -965)'/>
+        </g>
+    </g>
+</svg>

--- a/src/scalable/source-symbolic.svg
+++ b/src/scalable/source-symbolic.svg
@@ -43,13 +43,13 @@
      inkscape:snap-bbox="true"
      inkscape:snap-nodes="true"
      showborder="true"
-     inkscape:current-layer="g6449"
+     inkscape:current-layer="layer10"
      inkscape:window-maximized="1"
      inkscape:window-y="32"
      inkscape:window-x="0"
-     inkscape:cy="163.125"
-     inkscape:cx="160.65625"
-     inkscape:zoom="16"
+     inkscape:cy="566"
+     inkscape:cx="163.75"
+     inkscape:zoom="4"
      showgrid="false"
      id="namedview88"
      inkscape:window-height="1011"
@@ -5550,6 +5550,280 @@
          id="path10932-3"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccccccsccsccccscccccccccccccccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="translate(119.9998,238)"
+       id="g3169"
+       inkscape:label="audio-speaker">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;stroke:none;stroke-width:1;marker:none;fill-opacity:1"
+         id="rect3160"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="rect6148"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="M 151.07031 554.04883 C 150.86218 554.05716 150.65625 554.12723 150.5 554.25 L 147 557 L 146 557 L 145 557 C 144.446 557 144 557.446 144 558 L 144 562 C 144 562.554 144.446 563 145 563 L 146 563 L 147 563 L 150.5 565.75 C 151 566.14286 152 566 152 565 L 152 560 L 152 555 C 152 554.3125 151.5282 554.03051 151.07031 554.04883 z "
+         transform="translate(121.0004,-965)" />
+      <path
+         id="rect6998"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="rect7003"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="translate(139.9998,238)"
+       id="g8425"
+       inkscape:label="audio-speaker-left">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect8417"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path8419"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 276.47803,-409.68867 c -0.15282,-0.14151 -0.34822,-0.23735 -0.54552,-0.26102 l -4.41941,-0.53033 -0.70711,-0.70711 -0.70711,-0.70711 c -0.39173,-0.39173 -1.02247,-0.39173 -1.41421,0 l -2.82843,2.82843 c -0.39173,0.39174 -0.39173,1.02248 0,1.41421 l 0.70711,0.70711 0.70711,0.70711 0.53033,4.41942 c 0.0758,0.63134 0.88388,1.23743 1.59099,0.53033 l 3.53553,-3.53554 3.53553,-3.53553 c 0.48614,-0.48614 0.35192,-1.01915 0.0152,-1.32997 z" />
+      <path
+         id="path8421"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 275.3138,-405.79544 1.85614,0.97226 c -0.7071,2.12133 -2.12131,3.53555 -4.24264,4.24265 l -0.97226,-1.85615 c 2.12132,-0.70711 2.65165,-1.23744 3.35876,-3.35876 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path8423"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 278.62836,-404.86736 2.07712,0.7513 c -0.7071,3.53553 -3.53553,6.36396 -7.07106,7.07107 l -0.7513,-2.07713 c 3.53553,-0.70711 5.03813,-2.20971 5.74524,-5.74524 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="rotate(90,234.0003,-206.0001)"
+       id="g8436"
+       inkscape:label="audio-speaker-center">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect8427"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path8429"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path8432"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path8434"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="translate(179.9998,238)"
+       id="g8446"
+       inkscape:label="audio-speaker-right">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect8438"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path8440"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 277.82264,-401.43115 c 0.1415,-0.15282 0.23734,-0.34822 0.26102,-0.54552 l 0.53032,-4.41941 0.70711,-0.70711 0.70711,-0.70711 c 0.39173,-0.39173 0.39173,-1.02247 10e-6,-1.4142 l -2.82844,-2.82844 c -0.39173,-0.39172 -1.02247,-0.39172 -1.4142,10e-6 l -0.70711,0.70711 -0.70711,0.70711 -4.41943,0.53032 c -0.63133,0.0758 -1.23742,0.88389 -0.53033,1.59099 l 3.53554,3.53553 3.53554,3.53553 c 0.48614,0.48615 1.01914,0.35192 1.32997,0.0152 z" />
+      <path
+         id="path8442"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 273.9294,-402.59537 -0.97226,1.85613 c -2.12133,-0.7071 -3.53555,-2.1213 -4.24265,-4.24263 l 1.85615,-0.97226 c 0.70711,2.12132 1.23744,2.65165 3.35876,3.35876 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path8444"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 273.00132,-399.28081 -0.75129,2.07711 c -3.53553,-0.7071 -6.36397,-3.53553 -7.07108,-7.07106 l 2.07713,-0.75129 c 0.70712,3.53553 2.20971,5.03812 5.74524,5.74524 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="translate(139.9998,258)"
+       id="g8457"
+       inkscape:label="audio-speaker-left-side">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect8448"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path8450"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path8452"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path8454"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="rotate(180,363.0003,-276)"
+       id="g8467"
+       inkscape:label="audio-speaker-right-side">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect8459"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path8461"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path8463"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path8465"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="translate(139.9998,278)"
+       id="g8477"
+       inkscape:label="audio-speaker-left-back">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect8469"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path8471"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 268.06154,-408.72744 c -0.14151,0.15282 -0.23735,0.34822 -0.26102,0.54551 l -0.53033,4.41942 -0.70711,0.70711 -0.7071,0.70711 c -0.39174,0.39173 -0.39174,1.02247 0,1.41421 l 2.82842,2.82843 c 0.39174,0.39173 1.02248,0.39173 1.41422,0 l 0.7071,-0.70711 0.70711,-0.70711 4.41942,-0.53033 c 0.63134,-0.0758 1.23743,-0.88388 0.53033,-1.59099 l -3.53554,-3.53553 -3.53553,-3.53554 c -0.48614,-0.48613 -1.01915,-0.35192 -1.32997,-0.0152 z" />
+      <path
+         id="path8473"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 271.95477,-407.56321 0.97227,-1.85615 c 2.12132,0.7071 3.53554,2.12132 4.24264,4.24265 l -1.85615,0.97226 c -0.70711,-2.12132 -1.23744,-2.65165 -3.35876,-3.35876 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path8475"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 272.88285,-410.87777 0.7513,-2.07713 c 3.53553,0.70711 6.36396,3.53554 7.07107,7.07107 l -2.07713,0.7513 c -0.7071,-3.53553 -2.20971,-5.03813 -5.74524,-5.74524 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="rotate(-90,492.0003,-345.9999)"
+       id="g8487"
+       inkscape:label="audio-speaker-center-back">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect8479"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path8481"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path8483"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path8485"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="translate(179.9998,278)"
+       id="g8497"
+       inkscape:label="audio-speaker-right-back">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect8489"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path8491"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 269.40625,-400.15227 c 0.15282,0.14151 0.34822,0.23735 0.54551,0.26101 l 4.41943,0.53034 0.70711,0.70711 0.7071,0.7071 c 0.39173,0.39173 1.02247,0.39173 1.41421,0 l 2.82843,-2.82842 c 0.39173,-0.39175 0.39173,-1.02249 0,-1.41422 l -0.7071,-0.7071 -0.70711,-0.70711 -0.53034,-4.41942 c -0.0758,-0.63134 -0.88387,-1.23743 -1.59099,-0.53033 l -3.53552,3.53554 -3.53555,3.53552 c -0.48612,0.48615 -0.35192,1.01916 -0.0152,1.32998 z" />
+      <path
+         id="path8493"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 270.57048,-404.04549 -1.85615,-0.97228 c 0.7071,-2.12132 2.12132,-3.53554 4.24265,-4.24264 l 0.97227,1.85615 c -2.12132,0.70711 -2.65165,1.23744 -3.35877,3.35877 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path8495"
+         style="opacity:0.5;fill:#4c5263"
+         d="m 267.25593,-404.97358 -2.07714,-0.75131 c 0.70711,-3.53552 3.53554,-6.36395 7.07107,-7.07107 l 0.7513,2.07715 c -3.53553,0.70709 -5.03813,2.2097 -5.74523,5.74523 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="translate(199.9998,238)"
+       id="g8507"
+       inkscape:label="audio-subwoofer">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect8499"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <rect
+         style="opacity:0.35;fill:#4c5263;fill-opacity:1;stroke:none"
+         id="rect9188"
+         width="6"
+         height="6"
+         x="270.0004"
+         y="-405"
+         ry="3" />
+      <path
+         id="rect8888"
+         style="opacity:1;fill:#4c5263;fill-opacity:1;stroke:none"
+         d="M 228 552 C 226.892 552 226 552.892 226 554 L 226 566 C 226 567.108 226.892 568 228 568 L 236 568 C 237.108 568 238 567.108 238 566 L 238 554 C 238 552.892 237.108 552 236 552 L 228 552 z M 229 554 L 235 554 C 235.554 554 236 554.446 236 555 L 236 557 C 236 557.554 235.554 558 235 558 L 229 558 C 228.446 558 228 557.554 228 557 L 228 555 C 228 554.446 228.446 554 229 554 z M 228 559 A 1 1 0 0 1 229 560 A 1 1 0 0 1 228 561 A 1 1 0 0 1 227 560 A 1 1 0 0 1 228 559 z M 236 559 A 1 1 0 0 1 237 560 A 1 1 0 0 1 236 561 A 1 1 0 0 1 235 560 A 1 1 0 0 1 236 559 z M 232 560 C 233.662 560 235 561.338 235 563 C 235 564.662 233.662 566 232 566 C 230.338 566 229 564.662 229 563 C 229 561.338 230.338 560 232 560 z M 232 562 C 231.446 562 231 562.446 231 563 C 231 563.554 231.446 564 232 564 C 232.554 564 233 563.554 233 563 C 233 562.446 232.554 562 232 562 z M 228 565 A 1 1 0 0 1 229 566 A 1 1 0 0 1 228 567 A 1 1 0 0 1 227 566 A 1 1 0 0 1 228 565 z M 236 565 A 1 1 0 0 1 237 566 A 1 1 0 0 1 236 567 A 1 1 0 0 1 235 566 A 1 1 0 0 1 236 565 z "
+         transform="translate(41.0004,-965)" />
     </g>
   </g>
   <g

--- a/src/scalable/source-symbolic.svg
+++ b/src/scalable/source-symbolic.svg
@@ -43,13 +43,13 @@
      inkscape:snap-bbox="true"
      inkscape:snap-nodes="true"
      showborder="true"
-     inkscape:current-layer="layer10"
+     inkscape:current-layer="g3312"
      inkscape:window-maximized="1"
      inkscape:window-y="32"
      inkscape:window-x="0"
-     inkscape:cy="566"
-     inkscape:cx="163.75"
-     inkscape:zoom="4"
+     inkscape:cy="519.98862"
+     inkscape:cx="242.46533"
+     inkscape:zoom="4.4212506"
      showgrid="false"
      id="namedview88"
      inkscape:window-height="1011"
@@ -5801,7 +5801,7 @@
     </g>
     <g
        style="display:inline;enable-background:new"
-       transform="translate(199.9998,238)"
+       transform="translate(119.9998,278)"
        id="g8507"
        inkscape:label="audio-subwoofer">
       <rect
@@ -5822,7 +5822,281 @@
       <path
          id="rect8888"
          style="opacity:1;fill:#4c5263;fill-opacity:1;stroke:none"
-         d="M 228 552 C 226.892 552 226 552.892 226 554 L 226 566 C 226 567.108 226.892 568 228 568 L 236 568 C 237.108 568 238 567.108 238 566 L 238 554 C 238 552.892 237.108 552 236 552 L 228 552 z M 229 554 L 235 554 C 235.554 554 236 554.446 236 555 L 236 557 C 236 557.554 235.554 558 235 558 L 229 558 C 228.446 558 228 557.554 228 557 L 228 555 C 228 554.446 228.446 554 229 554 z M 228 559 A 1 1 0 0 1 229 560 A 1 1 0 0 1 228 561 A 1 1 0 0 1 227 560 A 1 1 0 0 1 228 559 z M 236 559 A 1 1 0 0 1 237 560 A 1 1 0 0 1 236 561 A 1 1 0 0 1 235 560 A 1 1 0 0 1 236 559 z M 232 560 C 233.662 560 235 561.338 235 563 C 235 564.662 233.662 566 232 566 C 230.338 566 229 564.662 229 563 C 229 561.338 230.338 560 232 560 z M 232 562 C 231.446 562 231 562.446 231 563 C 231 563.554 231.446 564 232 564 C 232.554 564 233 563.554 233 563 C 233 562.446 232.554 562 232 562 z M 228 565 A 1 1 0 0 1 229 566 A 1 1 0 0 1 228 567 A 1 1 0 0 1 227 566 A 1 1 0 0 1 228 565 z M 236 565 A 1 1 0 0 1 237 566 A 1 1 0 0 1 236 567 A 1 1 0 0 1 235 566 A 1 1 0 0 1 236 565 z "
+         d="m 228,552 c -1.108,0 -2,0.892 -2,2 v 12 c 0,1.108 0.892,2 2,2 h 8 c 1.108,0 2,-0.892 2,-2 v -12 c 0,-1.108 -0.892,-2 -2,-2 z m 1,2 h 6 c 0.554,0 1,0.446 1,1 v 2 c 0,0.554 -0.446,1 -1,1 h -6 c -0.554,0 -1,-0.446 -1,-1 v -2 c 0,-0.554 0.446,-1 1,-1 z m -1,5 a 1,1 0 0 1 1,1 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 1,-1 z m 8,0 a 1,1 0 0 1 1,1 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 1,-1 z m -4,1 c 1.662,0 3,1.338 3,3 0,1.662 -1.338,3 -3,3 -1.662,0 -3,-1.338 -3,-3 0,-1.662 1.338,-3 3,-3 z m 0,2 c -0.554,0 -1,0.446 -1,1 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 0,-0.554 -0.446,-1 -1,-1 z m -4,3 a 1,1 0 0 1 1,1 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 1,-1 z m 8,0 a 1,1 0 0 1 1,1 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 1,-1 z"
+         transform="translate(41.0004,-965)" />
+    </g>
+    <g
+       style="display:inline;enable-background:new;opacity:1"
+       transform="translate(119.9998,258)"
+       id="g3216"
+       inkscape:label="audio-speaker-testing">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect3208"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path3210"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path3212"
+         style="opacity:1;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path3214"
+         style="opacity:1;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="translate(199.9998,238)"
+       id="g3226"
+       inkscape:label="audio-speaker-left-testing">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect3218"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path3220"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 276.47803,-409.68867 c -0.15282,-0.14151 -0.34822,-0.23735 -0.54552,-0.26102 l -4.41941,-0.53033 -0.70711,-0.70711 -0.70711,-0.70711 c -0.39173,-0.39173 -1.02247,-0.39173 -1.41421,0 l -2.82843,2.82843 c -0.39173,0.39174 -0.39173,1.02248 0,1.41421 l 0.70711,0.70711 0.70711,0.70711 0.53033,4.41942 c 0.0758,0.63134 0.88388,1.23743 1.59099,0.53033 l 3.53553,-3.53554 3.53553,-3.53553 c 0.48614,-0.48614 0.35192,-1.01915 0.0152,-1.32997 z" />
+      <path
+         id="path3222"
+         style="opacity:1;fill:#4c5263"
+         d="m 275.3138,-405.79544 1.85614,0.97226 c -0.7071,2.12133 -2.12131,3.53555 -4.24264,4.24265 l -0.97226,-1.85615 c 2.12132,-0.70711 2.65165,-1.23744 3.35876,-3.35876 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path3224"
+         style="opacity:1;fill:#4c5263"
+         d="m 278.62836,-404.86736 2.07712,0.7513 c -0.7071,3.53553 -3.53553,6.36396 -7.07106,7.07107 l -0.7513,-2.07713 c 3.53553,-0.70711 5.03813,-2.20971 5.74524,-5.74524 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="rotate(90,264.0003,-176.0001)"
+       id="g3237"
+       inkscape:label="audio-speaker-center-testing">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect3229"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path3231"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path3233"
+         style="opacity:1;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path3235"
+         style="opacity:1;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="translate(239.9998,238)"
+       id="g3251"
+       inkscape:label="audio-speaker-right-testing">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect3243"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path3245"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 277.82264,-401.43115 c 0.1415,-0.15282 0.23734,-0.34822 0.26102,-0.54552 l 0.53032,-4.41941 0.70711,-0.70711 0.70711,-0.70711 c 0.39173,-0.39173 0.39173,-1.02247 10e-6,-1.4142 l -2.82844,-2.82844 c -0.39173,-0.39172 -1.02247,-0.39172 -1.4142,10e-6 l -0.70711,0.70711 -0.70711,0.70711 -4.41943,0.53032 c -0.63133,0.0758 -1.23742,0.88389 -0.53033,1.59099 l 3.53554,3.53553 3.53554,3.53553 c 0.48614,0.48615 1.01914,0.35192 1.32997,0.0152 z" />
+      <path
+         id="path3247"
+         style="opacity:1;fill:#4c5263"
+         d="m 273.9294,-402.59537 -0.97226,1.85613 c -2.12133,-0.7071 -3.53555,-2.1213 -4.24265,-4.24263 l 1.85615,-0.97226 c 0.70711,2.12132 1.23744,2.65165 3.35876,3.35876 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path3249"
+         style="opacity:1;fill:#4c5263"
+         d="m 273.00132,-399.28081 -0.75129,2.07711 c -3.53553,-0.7071 -6.36397,-3.53553 -7.07108,-7.07106 l 2.07713,-0.75129 c 0.70712,3.53553 2.20971,5.03812 5.74524,5.74524 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="translate(199.9998,258)"
+       id="g3261"
+       inkscape:label="audio-speaker-left-side-testing">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect3253"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path3255"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path3257"
+         style="opacity:1;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path3259"
+         style="opacity:1;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="rotate(180,393.0003,-276)"
+       id="g3271"
+       inkscape:label="audio-speaker-right-side-testing">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect3263"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path3265"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path3267"
+         style="opacity:1;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path3269"
+         style="opacity:1;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="translate(199.9998,278)"
+       id="g3281"
+       inkscape:label="audio-speaker-left-back-testing">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect3273"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path3275"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 268.06154,-408.72744 c -0.14151,0.15282 -0.23735,0.34822 -0.26102,0.54551 l -0.53033,4.41942 -0.70711,0.70711 -0.7071,0.70711 c -0.39174,0.39173 -0.39174,1.02247 0,1.41421 l 2.82842,2.82843 c 0.39174,0.39173 1.02248,0.39173 1.41422,0 l 0.7071,-0.70711 0.70711,-0.70711 4.41942,-0.53033 c 0.63134,-0.0758 1.23743,-0.88388 0.53033,-1.59099 l -3.53554,-3.53553 -3.53553,-3.53554 c -0.48614,-0.48613 -1.01915,-0.35192 -1.32997,-0.0152 z" />
+      <path
+         id="path3277"
+         style="opacity:1;fill:#4c5263"
+         d="m 271.95477,-407.56321 0.97227,-1.85615 c 2.12132,0.7071 3.53554,2.12132 4.24264,4.24265 l -1.85615,0.97226 c -0.70711,-2.12132 -1.23744,-2.65165 -3.35876,-3.35876 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path3279"
+         style="opacity:1;fill:#4c5263"
+         d="m 272.88285,-410.87777 0.7513,-2.07713 c 3.53553,0.70711 6.36396,3.53554 7.07107,7.07107 l -2.07713,0.7513 c -0.7071,-3.53553 -2.20971,-5.03813 -5.74524,-5.74524 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="rotate(-90,522.0003,-375.9999)"
+       id="g3293"
+       inkscape:label="audio-speaker-center-back-testing">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect3284"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path3287"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path3289"
+         style="opacity:1;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path3291"
+         style="opacity:1;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="translate(239.9998,278)"
+       id="g3304"
+       inkscape:label="audio-speaker-right-back-testing">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect3295"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path3297"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 269.40625,-400.15227 c 0.15282,0.14151 0.34822,0.23735 0.54551,0.26101 l 4.41943,0.53034 0.70711,0.70711 0.7071,0.7071 c 0.39173,0.39173 1.02247,0.39173 1.41421,0 l 2.82843,-2.82842 c 0.39173,-0.39175 0.39173,-1.02249 0,-1.41422 l -0.7071,-0.7071 -0.70711,-0.70711 -0.53034,-4.41942 c -0.0758,-0.63134 -0.88387,-1.23743 -1.59099,-0.53033 l -3.53552,3.53554 -3.53555,3.53552 c -0.48612,0.48615 -0.35192,1.01916 -0.0152,1.32998 z" />
+      <path
+         id="path3300"
+         style="opacity:1;fill:#4c5263"
+         d="m 270.57048,-404.04549 -1.85615,-0.97228 c 0.7071,-2.12132 2.12132,-3.53554 4.24265,-4.24264 l 0.97227,1.85615 c -2.12132,0.70711 -2.65165,1.23744 -3.35877,3.35877 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path3302"
+         style="opacity:1;fill:#4c5263"
+         d="m 267.25593,-404.97358 -2.07714,-0.75131 c 0.70711,-3.53552 3.53554,-6.36395 7.07107,-7.07107 l 0.7513,2.07715 c -3.53553,0.70709 -5.03813,2.2097 -5.74523,5.74523 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;enable-background:new"
+       transform="translate(259.9998,238)"
+       id="g3312"
+       inkscape:label="audio-subwoofer-testing">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect3306"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <rect
+         style="opacity:0.35;fill:#4caf50;fill-opacity:1;stroke:none"
+         id="rect3308"
+         width="6"
+         height="6"
+         x="270.0004"
+         y="-405"
+         ry="3" />
+      <path
+         id="path3310"
+         style="opacity:1;fill:#4c5263;fill-opacity:1;stroke:none"
+         d="m 228,552 c -1.108,0 -2,0.892 -2,2 v 12 c 0,1.108 0.892,2 2,2 h 8 c 1.108,0 2,-0.892 2,-2 v -12 c 0,-1.108 -0.892,-2 -2,-2 z m 1,2 h 6 c 0.554,0 1,0.446 1,1 v 2 c 0,0.554 -0.446,1 -1,1 h -6 c -0.554,0 -1,-0.446 -1,-1 v -2 c 0,-0.554 0.446,-1 1,-1 z m -1,5 a 1,1 0 0 1 1,1 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 1,-1 z m 8,0 a 1,1 0 0 1 1,1 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 1,-1 z m -4,1 c 1.662,0 3,1.338 3,3 0,1.662 -1.338,3 -3,3 -1.662,0 -3,-1.338 -3,-3 0,-1.662 1.338,-3 3,-3 z m 0,2 c -0.554,0 -1,0.446 -1,1 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 0,-0.554 -0.446,-1 -1,-1 z m -4,3 a 1,1 0 0 1 1,1 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 1,-1 z m 8,0 a 1,1 0 0 1 1,1 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 1,-1 z"
          transform="translate(41.0004,-965)" />
     </g>
   </g>


### PR DESCRIPTION
Adds symbolic surround-sound speaker icons.

Previously the icons used in System Settings > Sound > Test were built into Settings, and since the builtin icons are not symbolic, they would not be recolored correctly, leading to poor contrast in the dark theme. This updates these icons with symbolic versions provided by the theme, so that the icons correctly get recolored based on the theme, improving contrast:

![Screenshot from 2021-09-24 16-43-30](https://user-images.githubusercontent.com/5883565/134746733-1675828f-cb28-481f-a171-ded810fcd030.png)

Requires #89 
