### PR TITLE
feat(scalable): sync the volume status icons with new speakers

### DIFF
--- a/Pop/scalable/devices/audio-speakers-symbolic.svg
+++ b/Pop/scalable/devices/audio-speakers-symbolic.svg
@@ -1,47 +1,14 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata90'>
-    <rdf:RDF>
-      <cc:Work rdf:about=''>
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
-        <dc:title>Pop Symbolic Icon Theme</dc:title>
-        <cc:license rdf:resource='http://creativecommons.org/licenses/by-sa/4.0/'/>
-      </cc:Work>
-      <cc:License rdf:about='http://creativecommons.org/licenses/by-sa/4.0/'>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#Reproduction'/>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#Distribution'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#Notice'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#Attribution'/>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#DerivativeWorks'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#ShareAlike'/>
-      </cc:License>
-    </rdf:RDF>
-  </metadata>
-  <title id='title8473'>Pop Symbolic Icon Theme</title>
-  <defs id='defs7386'>
-    <linearGradient id='linearGradient6882' osb:paint='solid'>
-      <stop id='stop6884' offset='0' style='stop-color:#555555;stop-opacity:1;'/>
-    </linearGradient>
-    <linearGradient id='linearGradient5606' osb:paint='solid'>
-      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
-    </linearGradient>
-    <filter id='filter7554' style='color-interpolation-filters:sRGB'>
-      <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
-    </filter>
-  </defs>
-  <g id='layer9' style='display:inline' transform='translate(-445.0002,195)'/>
-  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-445.0002,195)'>
-    
-    <path d='m 452.0002,-195 -7,8 7,8 z m -5,8 v -3 c 0,-0.554 -0.446,-1 -1,-1 -0.554,0 -1,0.446 -1,1 v 6 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 z' id='rect2976-75-3' style='display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new'/>
-    <path d='m 458.0002,-194 -1.71289,1.0293 c 0.93437,1.55547 1.71307,4.15617 1.71289,5.9707 1.8e-4,1.81453 -0.77852,4.41523 -1.71289,5.9707 L 458.0002,-180 c 1.12166,-1.86618 1.9996,-4.82268 2,-7 -4e-4,-2.17732 -0.87834,-5.13382 -2,-7 z' id='path3022-3-6' style='display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new'/>
-    <path d='m 454.7502,-192.5 -1.71484,1.0293 c 0.6543,1.08883 0.96483,3.2004 0.96484,4.4707 -1e-5,1.2703 -0.31054,3.38187 -0.96484,4.4707 l 1.71484,1.0293 c 0.84091,-1.39973 1.25,-3.8671 1.25,-5.5 0,-1.6329 -0.40909,-4.10027 -1.25,-5.5 z' id='path3027-5-7' style='display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new'/>
-  </g>
-  <g id='layer1' style='display:inline' transform='translate(-204,-422)'/>
-  <g id='layer14' style='display:inline' transform='translate(-445.0002,195)'/>
-  <g id='layer15' style='display:inline' transform='translate(-445.0002,195)'/>
-  <g id='g71291' style='display:inline' transform='translate(-445.0002,195)'/>
-  <g id='layer2' style='display:inline' transform='translate(-204,-272)'/>
-  <g id='layer3' transform='translate(-204,-532)'/>
-  <g id='layer12' style='display:inline' transform='translate(-445.0002,195)'/>
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline;filter:url(#a)' transform='translate(-445 195)'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(180 218)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:1;fill:#4c5263'/>
+        </g>
+    </g>
 </svg>

--- a/Pop/scalable/status/audio-volume-high-symbolic.svg
+++ b/Pop/scalable/status/audio-volume-high-symbolic.svg
@@ -1,47 +1,17 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16.000013' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='15.999996' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata90'>
-    <rdf:RDF>
-      <cc:Work rdf:about=''>
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
-        <dc:title>Pop Symbolic Icon Theme</dc:title>
-        <cc:license rdf:resource='http://creativecommons.org/licenses/by-sa/4.0/'/>
-      </cc:Work>
-      <cc:License rdf:about='http://creativecommons.org/licenses/by-sa/4.0/'>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#Reproduction'/>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#Distribution'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#Notice'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#Attribution'/>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#DerivativeWorks'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#ShareAlike'/>
-      </cc:License>
-    </rdf:RDF>
-  </metadata>
-  <title id='title8473'>Pop Symbolic Icon Theme</title>
-  <defs id='defs7386'>
-    <linearGradient id='linearGradient6882' osb:paint='solid'>
-      <stop id='stop6884' offset='0' style='stop-color:#555555;stop-opacity:1;'/>
-    </linearGradient>
-    <linearGradient id='linearGradient5606' osb:paint='solid'>
-      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
-    </linearGradient>
-    <filter id='filter7554' style='color-interpolation-filters:sRGB'>
-      <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
-    </filter>
-  </defs>
-  <g id='layer9' style='display:inline' transform='translate(-345.0002,535.00001)'>
-    
-    <path d='m 353.0002,-535 -7,8 7,8 z m -5,8 v -3 c 0,-0.554 -0.446,-1 -1,-1 -0.554,0 -1,0.446 -1,1 v 6 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 z' id='rect2976-75' style='opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549'/>
-    <path d='m 359.0002,-534 -1.71289,1.0293 c 0.93437,1.55547 1.71307,4.15617 1.71289,5.9707 1.8e-4,1.81453 -0.77852,4.41523 -1.71289,5.9707 L 359.0002,-520 c 1.12166,-1.86618 1.9996,-4.82268 2,-7 -4e-4,-2.17732 -0.87834,-5.13382 -2,-7 z' id='path3022-3' style='opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549'/>
-    <path d='m 355.7502,-532.5 -1.71484,1.0293 c 0.6543,1.08883 0.96483,3.2004 0.96484,4.4707 -1e-5,1.2703 -0.31054,3.38187 -0.96484,4.4707 l 1.71484,1.0293 c 0.84091,-1.39973 1.25,-3.8671 1.25,-5.5 0,-1.6329 -0.40909,-4.10027 -1.25,-5.5 z' id='path3027-5' style='opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549'/>
-  </g>
-  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-345.0002,535.00001)'/>
-  <g id='layer1' style='display:inline' transform='translate(-104,-81.999986)'/>
-  <g id='layer14' style='display:inline' transform='translate(-345.0002,535.00001)'/>
-  <g id='layer15' style='display:inline' transform='translate(-345.0002,535.00001)'/>
-  <g id='g71291' style='display:inline' transform='translate(-345.0002,535.00001)'/>
-  <g id='layer2' style='display:inline' transform='translate(-104,68.000014)'/>
-  <g id='layer3' transform='translate(-104,-191.99999)'/>
-  <g id='layer12' style='display:inline' transform='translate(-345.0002,535.00001)'/>
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='b' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(-265 413)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:1;fill:#4c5263'/>
+        </g>
+    </g>
 </svg>

--- a/Pop/scalable/status/audio-volume-low-symbolic.svg
+++ b/Pop/scalable/status/audio-volume-low-symbolic.svg
@@ -1,47 +1,17 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16.001671' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16.000004' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata90'>
-    <rdf:RDF>
-      <cc:Work rdf:about=''>
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
-        <dc:title>Pop Symbolic Icon Theme</dc:title>
-        <cc:license rdf:resource='http://creativecommons.org/licenses/by-sa/4.0/'/>
-      </cc:Work>
-      <cc:License rdf:about='http://creativecommons.org/licenses/by-sa/4.0/'>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#Reproduction'/>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#Distribution'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#Notice'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#Attribution'/>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#DerivativeWorks'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#ShareAlike'/>
-      </cc:License>
-    </rdf:RDF>
-  </metadata>
-  <title id='title8473'>Pop Symbolic Icon Theme</title>
-  <defs id='defs7386'>
-    <linearGradient id='linearGradient6882' osb:paint='solid'>
-      <stop id='stop6884' offset='0' style='stop-color:#555555;stop-opacity:1;'/>
-    </linearGradient>
-    <linearGradient id='linearGradient5606' osb:paint='solid'>
-      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
-    </linearGradient>
-    <filter id='filter7554' style='color-interpolation-filters:sRGB'>
-      <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
-    </filter>
-  </defs>
-  <g id='layer9' style='display:inline' transform='translate(-405.0002,535)'>
-    
-    <path d='m 419.0002,-534.00063 -1.71289,1.0293 c 0.93437,1.55547 1.71307,4.15617 1.71289,5.9707 1.8e-4,1.81453 -0.77852,4.41523 -1.71289,5.9707 l 1.71289,1.0293 c 1.12166,-1.86618 1.9996,-4.82268 2,-7 -4e-4,-2.17732 -0.87834,-5.13382 -2,-7 z' id='path3022-9' style='display:inline;opacity:0.35;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new'/>
-    <path d='m 415.7502,-532.50063 -1.71484,1.0293 c 0.6543,1.08883 0.96483,3.2004 0.96484,4.4707 -1e-5,1.2703 -0.31054,3.38187 -0.96484,4.4707 l 1.71484,1.0293 c 0.84091,-1.39973 1.25,-3.8671 1.25,-5.5 0,-1.6329 -0.40909,-4.10027 -1.25,-5.5 z' id='path3027-2' style='display:inline;opacity:0.35;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new'/>
-    <path d='m 413.0002,-535 -7,8 7,8 z m -5,5 c 0,-0.554 -0.446,-1 -1,-1 -0.554,0 -1,0.446 -1,1 v 6 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 z' id='rect2976-5' style='display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new'/>
-  </g>
-  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-405.0002,535)'/>
-  <g id='layer1' style='display:inline' transform='translate(-164,-82)'/>
-  <g id='layer14' style='display:inline' transform='translate(-405.0002,535)'/>
-  <g id='layer15' style='display:inline' transform='translate(-405.0002,535)'/>
-  <g id='g71291' style='display:inline' transform='translate(-405.0002,535)'/>
-  <g id='layer2' style='display:inline' transform='translate(-164,68)'/>
-  <g id='layer3' transform='translate(-164,-192)'/>
-  <g id='layer12' style='display:inline' transform='translate(-405.0002,535)'/>
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='b' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(-265 413)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:.35;fill:#4c5263'/>
+        </g>
+    </g>
 </svg>

--- a/Pop/scalable/status/audio-volume-medium-symbolic.svg
+++ b/Pop/scalable/status/audio-volume-medium-symbolic.svg
@@ -1,47 +1,18 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16.001671' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16.000004' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata90'>
-    <rdf:RDF>
-      <cc:Work rdf:about=''>
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
-        <dc:title>Pop Symbolic Icon Theme</dc:title>
-        <cc:license rdf:resource='http://creativecommons.org/licenses/by-sa/4.0/'/>
-      </cc:Work>
-      <cc:License rdf:about='http://creativecommons.org/licenses/by-sa/4.0/'>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#Reproduction'/>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#Distribution'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#Notice'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#Attribution'/>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#DerivativeWorks'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#ShareAlike'/>
-      </cc:License>
-    </rdf:RDF>
-  </metadata>
-  <title id='title8473'>Pop Symbolic Icon Theme</title>
-  <defs id='defs7386'>
-    <linearGradient id='linearGradient6882' osb:paint='solid'>
-      <stop id='stop6884' offset='0' style='stop-color:#555555;stop-opacity:1;'/>
-    </linearGradient>
-    <linearGradient id='linearGradient5606' osb:paint='solid'>
-      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
-    </linearGradient>
-    <filter id='filter7554' style='color-interpolation-filters:sRGB'>
-      <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
-    </filter>
-  </defs>
-  <g id='layer9' style='display:inline' transform='translate(-385.0002,535)'>
-    
-    <path d='m 399.0002,-534 -1.71289,1.0293 c 0.93437,1.55547 1.71307,4.15617 1.71289,5.9707 1.8e-4,1.81453 -0.77852,4.41523 -1.71289,5.9707 L 399.0002,-520 c 1.12166,-1.86618 1.9996,-4.82268 2,-7 -4e-4,-2.17732 -0.87834,-5.13382 -2,-7 z' id='path3022-8' style='display:inline;opacity:0.35;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new'/>
-    <path d='m 395.7502,-532.5 -1.71484,1.0293 c 0.6543,1.08883 0.96483,3.2004 0.96484,4.4707 -1e-5,1.2703 -0.31054,3.38187 -0.96484,4.4707 l 1.71484,1.0293 c 0.84091,-1.39973 1.25,-3.8671 1.25,-5.5 0,-1.6329 -0.40909,-4.10027 -1.25,-5.5 z' id='path3027-7' style='display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new'/>
-    <path d='m 393.0002,-535 -7,8 7,8 z m -5,5 c 0,-0.554 -0.446,-1 -1,-1 -0.554,0 -1,0.446 -1,1 v 6 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 z' id='rect2976-7' style='display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new'/>
-  </g>
-  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-385.0002,535)'/>
-  <g id='layer1' style='display:inline' transform='translate(-144,-82)'/>
-  <g id='layer14' style='display:inline' transform='translate(-385.0002,535)'/>
-  <g id='layer15' style='display:inline' transform='translate(-385.0002,535)'/>
-  <g id='g71291' style='display:inline' transform='translate(-385.0002,535)'/>
-  <g id='layer2' style='display:inline' transform='translate(-144,68)'/>
-  <g id='layer3' transform='translate(-144,-192)'/>
-  <g id='layer12' style='display:inline' transform='translate(-385.0002,535)'/>
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='b' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(-265 413)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75z' style='opacity:1;fill:#4c5263'/>
+            <path d='m277-409.063 2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:.35;fill:#4c5263'/>
+        </g>
+    </g>
 </svg>

--- a/Pop/scalable/status/audio-volume-muted-symbolic.svg
+++ b/Pop/scalable/status/audio-volume-muted-symbolic.svg
@@ -1,47 +1,17 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16.001671' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16.000004' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata90'>
-    <rdf:RDF>
-      <cc:Work rdf:about=''>
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
-        <dc:title>Pop Symbolic Icon Theme</dc:title>
-        <cc:license rdf:resource='http://creativecommons.org/licenses/by-sa/4.0/'/>
-      </cc:Work>
-      <cc:License rdf:about='http://creativecommons.org/licenses/by-sa/4.0/'>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#Reproduction'/>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#Distribution'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#Notice'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#Attribution'/>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#DerivativeWorks'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#ShareAlike'/>
-      </cc:License>
-    </rdf:RDF>
-  </metadata>
-  <title id='title8473'>Pop Symbolic Icon Theme</title>
-  <defs id='defs7386'>
-    <linearGradient id='linearGradient6882' osb:paint='solid'>
-      <stop id='stop6884' offset='0' style='stop-color:#555555;stop-opacity:1;'/>
-    </linearGradient>
-    <linearGradient id='linearGradient5606' osb:paint='solid'>
-      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
-    </linearGradient>
-    <filter id='filter7554' style='color-interpolation-filters:sRGB'>
-      <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
-    </filter>
-  </defs>
-  <g id='layer9' style='display:inline' transform='translate(-425.0002,535)'>
-    
-    <path d='m 439.0002,-534 -1.71289,1.0293 c 0.93437,1.55547 1.71307,4.15617 1.71289,5.9707 1.8e-4,1.81453 -0.77852,4.41523 -1.71289,5.9707 L 439.0002,-520 c 1.12166,-1.86618 1.9996,-4.82268 2,-7 -4e-4,-2.17732 -0.87834,-5.13382 -2,-7 z' id='path3022-0' style='display:inline;opacity:0.35;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new'/>
-    <path d='m 435.7502,-532.5 -1.71484,1.0293 c 0.6543,1.08883 0.96483,3.2004 0.96484,4.4707 -1e-5,1.2703 -0.31054,3.38187 -0.96484,4.4707 l 1.71484,1.0293 c 0.84091,-1.39973 1.25,-3.8671 1.25,-5.5 0,-1.6329 -0.40909,-4.10027 -1.25,-5.5 z' id='path3027-23' style='display:inline;opacity:0.35;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new'/>
-    <path d='m 433.0002,-535 -7,8.04688 7,7.95312 z m -5,5 c 0,-0.554 -0.446,-1 -1,-1 -0.554,0 -1,0.446 -1,1 v 6 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 z' id='rect2976-9' style='display:inline;opacity:0.35;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new'/>
-  </g>
-  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-425.0002,535)'/>
-  <g id='layer1' style='display:inline' transform='translate(-184,-82)'/>
-  <g id='layer14' style='display:inline' transform='translate(-425.0002,535)'/>
-  <g id='layer15' style='display:inline' transform='translate(-425.0002,535)'/>
-  <g id='g71291' style='display:inline' transform='translate(-425.0002,535)'/>
-  <g id='layer2' style='display:inline' transform='translate(-184,68)'/>
-  <g id='layer3' transform='translate(-184,-192)'/>
-  <g id='layer12' style='display:inline' transform='translate(-425.0002,535)'/>
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='b' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(-265 413)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:.35;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:.35;fill:#4c5263'/>
+        </g>
+    </g>
 </svg>

--- a/Pop/scalable/status/audio-volume-overamplified-symbolic.svg
+++ b/Pop/scalable/status/audio-volume-overamplified-symbolic.svg
@@ -1,51 +1,19 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16.000013' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' style='enable-background:new' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='15.999996' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata90'>
-    <rdf:RDF>
-      <cc:Work rdf:about=''>
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
-        <dc:title>Pop Symbolic Icon Theme</dc:title>
-        <cc:license rdf:resource='http://creativecommons.org/licenses/by-sa/4.0/'/>
-      </cc:Work>
-      <cc:License rdf:about='http://creativecommons.org/licenses/by-sa/4.0/'>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#Reproduction'/>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#Distribution'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#Notice'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#Attribution'/>
-        <cc:permits rdf:resource='http://creativecommons.org/ns#DerivativeWorks'/>
-        <cc:requires rdf:resource='http://creativecommons.org/ns#ShareAlike'/>
-      </cc:License>
-    </rdf:RDF>
-  </metadata>
-  <title id='title8473'>Pop Symbolic Icon Theme</title>
-  <defs id='defs7386'>
-    <linearGradient id='linearGradient6882' osb:paint='solid'>
-      <stop id='stop6884' offset='0' style='stop-color:#555555;stop-opacity:1;'/>
-    </linearGradient>
-    <linearGradient id='linearGradient5606' osb:paint='solid'>
-      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
-    </linearGradient>
-    <filter id='filter7554' style='color-interpolation-filters:sRGB'>
-      <feBlend id='feBlend7556' in2='BackgroundImage' mode='darken'/>
-    </filter>
-  </defs>
-  <g id='layer9' style='display:inline' transform='translate(-365.0002,535.00001)'>
-    
-    <path d='m 373.0002,-535 -7,8 7,8 z m -5,8 v -3 c 0,-0.554 -0.446,-1 -1,-1 -0.554,0 -1,0.446 -1,1 v 6 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 z' id='rect2976' style='opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549'/>
-    <path d='m 379.0002,-534 -1.71289,1.0293 c 0.93437,1.55547 1.71307,4.15617 1.71289,5.9707 1.8e-4,1.81453 -0.77852,4.41523 -1.71289,5.9707 L 379.0002,-520 c 1.12166,-1.86618 1.9996,-4.82268 2,-7 -4e-4,-2.17732 -0.87834,-5.13382 -2,-7 z' id='path3022' style='opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549'/>
-    <path d='m 375.7502,-532.5 -1.71484,1.0293 c 0.6543,1.08883 0.96483,3.2004 0.96484,4.4707 -1e-5,1.2703 -0.31054,3.38187 -0.96484,4.4707 l 1.71484,1.0293 c 0.84091,-1.39973 1.25,-3.8671 1.25,-5.5 0,-1.6329 -0.40909,-4.10027 -1.25,-5.5 z' id='path3027' style='opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549'/>
-    <path d='m 374.0002,-521 h 3 v 2 h -1 z' id='path2948' style='opacity:0.5;fill:#f44336;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1'/>
-    <path d='m 374.0002,-533 h 3 v -2 h -1 z' id='path2948-6' style='display:inline;opacity:0.5;fill:#f44336;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new'/>
-    <path d='m 380.0002,-535 h 1 v 1 h -1 z' id='path2965' style='opacity:0.5;fill:#f44336;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1'/>
-    <path d='m 380.0002,-520 h 1 v 1 h -1 z' id='path2965-2' style='display:inline;opacity:0.5;fill:#f44336;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new'/>
-  </g>
-  <g id='layer10' style='display:inline;filter:url(#filter7554)' transform='translate(-365.0002,535.00001)'/>
-  <g id='layer1' style='display:inline' transform='translate(-124,-81.999986)'/>
-  <g id='layer14' style='display:inline' transform='translate(-365.0002,535.00001)'/>
-  <g id='layer15' style='display:inline' transform='translate(-365.0002,535.00001)'/>
-  <g id='g71291' style='display:inline' transform='translate(-365.0002,535.00001)'/>
-  <g id='layer2' style='display:inline' transform='translate(-124,68.000014)'/>
-  <g id='layer3' transform='translate(-124,-191.99999)'/>
-  <g id='layer12' style='display:inline' transform='translate(-365.0002,535.00001)'/>
+<svg height='16' style='enable-background:new' width='16' xmlns='http://www.w3.org/2000/svg'>
+    <defs>
+        <filter height='1' id='b' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+        <filter height='1' id='a' style='color-interpolation-filters:sRGB' width='1' x='0' y='0'>
+            <feBlend in2='BackgroundImage' mode='darken'/>
+        </filter>
+    </defs>
+    <g style='display:inline'>
+        <g style='display:inline;filter:url(#a);enable-background:new' transform='translate(-265 413)'>
+            <path d='M265-413h16v16h-16z' style='color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none'/>
+            <path d='M151.07 554.049a.995.995 0 0 0-.57.201L147 557h-2c-.554 0-1 .446-1 1v4c0 .554.446 1 1 1h2l3.5 2.75c.5.393 1.5.25 1.5-.75v-10c0-.688-.472-.97-.93-.951z' style='opacity:1;fill:#4c5263;fill-opacity:1' transform='translate(121 -965)'/>
+            <path d='m274-407.375 2-.625c1 2 1 4 0 6l-2-.625c1-2 1-2.75 0-4.75zM277-409.063l2-.937c2 3 2 7 0 10l-2-.938c2-3 2-5.125 0-8.125z' style='opacity:1;fill:#4c5263'/>
+            <path d='M274-411h2v12h-2z' style='opacity:.35;fill:#4c5263;stroke-width:.954314'/>
+            <path d='M278-413h2v16h-2z' style='opacity:.35;fill:#4c5263'/>
+        </g>
+    </g>
 </svg>

--- a/src/scalable/source-symbolic.svg
+++ b/src/scalable/source-symbolic.svg
@@ -43,13 +43,13 @@
      inkscape:snap-bbox="true"
      inkscape:snap-nodes="true"
      showborder="true"
-     inkscape:current-layer="g3312"
+     inkscape:current-layer="layer9"
      inkscape:window-maximized="1"
      inkscape:window-y="32"
      inkscape:window-x="0"
-     inkscape:cy="519.98862"
-     inkscape:cx="242.46533"
-     inkscape:zoom="4.4212506"
+     inkscape:cy="186.5"
+     inkscape:cx="159.875"
+     inkscape:zoom="8"
      showgrid="false"
      id="namedview88"
      inkscape:window-height="1011"
@@ -2083,120 +2083,6 @@
          style="fill:#4c5263;fill-opacity:1;stroke:none" />
     </g>
     <g
-       transform="translate(159.9998,-121.99833)"
-       id="g5101"
-       inkscape:label="audio-volume-muted">
-      <rect
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:1;marker:none"
-         id="rect5103"
-         width="16"
-         height="16"
-         x="265.0004"
-         y="-413" />
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3022-0"
-         d="m 279.0004,-412.00167 -1.71289,1.0293 c 0.93437,1.55547 1.71307,4.15617 1.71289,5.9707 1.8e-4,1.81453 -0.77852,4.41523 -1.71289,5.9707 l 1.71289,1.0293 c 1.12166,-1.86618 1.9996,-4.82268 2,-7 -4e-4,-2.17732 -0.87834,-5.13382 -2,-7 z"
-         style="display:inline;opacity:0.35;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new" />
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3027-23"
-         d="m 275.7504,-410.50167 -1.71484,1.0293 c 0.6543,1.08883 0.96483,3.2004 0.96484,4.4707 -1e-5,1.2703 -0.31054,3.38187 -0.96484,4.4707 l 1.71484,1.0293 c 0.84091,-1.39973 1.25,-3.8671 1.25,-5.5 0,-1.6329 -0.40909,-4.10027 -1.25,-5.5 z"
-         style="display:inline;opacity:0.35;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new" />
-      <path
-         sodipodi:nodetypes="cccccsssscc"
-         inkscape:connector-curvature="0"
-         id="rect2976-9"
-         d="m 273.0004,-413.00167 -7,8.04688 7,7.95312 z m -5,5 c 0,-0.554 -0.446,-1 -1,-1 -0.554,0 -1,0.446 -1,1 v 6 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 z"
-         style="display:inline;opacity:0.35;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new" />
-    </g>
-    <g
-       transform="translate(100.0454,-122.04399)"
-       id="g5071"
-       inkscape:label="audio-volume-overamplified">
-      <rect
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
-         id="rect5073"
-         width="15.999996"
-         height="16.000013"
-         x="264.9548"
-         y="-412.95602" />
-      <path
-         sodipodi:nodetypes="cccccssssssc"
-         inkscape:connector-curvature="0"
-         id="rect2976"
-         transform="translate(160.9548,-604.95601)"
-         d="m 112,192 -7,8 7,8 z m -5,8 v -3 c 0,-0.554 -0.446,-1 -1,-1 -0.554,0 -1,0.446 -1,1 v 6 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 z"
-         style="opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549" />
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3022"
-         transform="translate(160.9548,-604.95601)"
-         d="m 118,193 -1.71289,1.0293 c 0.93437,1.55547 1.71307,4.15617 1.71289,5.9707 1.8e-4,1.81453 -0.77852,4.41523 -1.71289,5.9707 L 118,207 c 1.12166,-1.86618 1.9996,-4.82268 2,-7 -4e-4,-2.17732 -0.87834,-5.13382 -2,-7 z"
-         style="opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549" />
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3027"
-         d="m 275.7048,-410.45601 -1.71484,1.0293 c 0.6543,1.08883 0.96483,3.2004 0.96484,4.4707 -10e-6,1.2703 -0.31054,3.38187 -0.96484,4.4707 l 1.71484,1.0293 c 0.84091,-1.39973 1.25,-3.8671 1.25,-5.5 0,-1.6329 -0.40909,-4.10027 -1.25,-5.5 z"
-         style="opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path2948"
-         d="m 273.9548,-398.95601 h 3 v 2 h -1 z"
-         style="fill:#f44336;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.5" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path2948-6"
-         d="m 273.9548,-410.95601 h 3 v -2 h -1 z"
-         style="display:inline;fill:#f44336;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new;opacity:0.5" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path2965"
-         d="m 279.9548,-412.95601 h 1 v 1 h -1 z"
-         style="fill:#f44336;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1;opacity:0.5" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path2965-2"
-         d="m 279.9548,-397.95601 h 1 v 1 h -1 z"
-         style="display:inline;fill:#f44336;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new;opacity:0.5" />
-    </g>
-    <g
-       inkscape:label="audio-volume-low"
-       id="g6038"
-       transform="translate(139.9998,-121.99833)">
-      <rect
-         y="-413"
-         x="265.0004"
-         height="16"
-         width="16"
-         id="rect6040"
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:1;marker:none" />
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3022-9"
-         d="m 279.0004,-412.0023 -1.71289,1.0293 c 0.93437,1.55547 1.71307,4.15617 1.71289,5.9707 1.8e-4,1.81453 -0.77852,4.41523 -1.71289,5.9707 l 1.71289,1.0293 c 1.12166,-1.86618 1.9996,-4.82268 2,-7 -4e-4,-2.17732 -0.87834,-5.13382 -2,-7 z"
-         style="display:inline;opacity:0.35;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new" />
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3027-2"
-         d="m 275.7504,-410.5023 -1.71484,1.0293 c 0.6543,1.08883 0.96483,3.2004 0.96484,4.4707 -1e-5,1.2703 -0.31054,3.38187 -0.96484,4.4707 l 1.71484,1.0293 c 0.84091,-1.39973 1.25,-3.8671 1.25,-5.5 0,-1.6329 -0.40909,-4.10027 -1.25,-5.5 z"
-         style="display:inline;opacity:0.35;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new" />
-      <path
-         sodipodi:nodetypes="cccccsssscc"
-         inkscape:connector-curvature="0"
-         id="rect2976-5"
-         d="m 273.0004,-413.00167 -7,8 7,8 z m -5,5 c 0,-0.554 -0.446,-1 -1,-1 -0.554,0 -1,0.446 -1,1 v 6 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 z"
-         style="display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new" />
-    </g>
-    <g
        transform="translate(-119.99684,-204.99499)"
        inkscape:label="network-transmit-receive"
        id="g9709">
@@ -2517,37 +2403,6 @@
          transform="translate(200.99942,-626.00069)"
          d="M 152 212.00195 C 150.33791 212.00195 149 213.33987 149 215.00195 L 149 220.00195 C 149 221.66403 150.33791 223.00195 152 223.00195 C 153.66208 223.00195 155 221.66403 155 220.00195 L 155 215.00195 C 155 213.33987 153.66208 212.00195 152 212.00195 z M 152 214.00195 C 152.554 214.00195 153 214.44795 153 215.00195 L 153 220.00195 C 153 220.55595 152.554 221.00195 152 221.00195 C 151.446 221.00195 151 220.55595 151 220.00195 L 151 215.00195 C 151 214.44795 151.446 214.00195 152 214.00195 z M 147 219 A 1 1 0 0 0 146 220 A 1 1 0 0 1 146 220.00195 C 146 220.00327 146 220.00455 146 220.00586 A 1 1 0 0 0 146.00391 220.08789 C 146.04553 223.01848 148.19004 225.43874 151 225.9082 L 151 227 A 1 1 0 0 0 152 228 A 1 1 0 0 0 153 227 L 153 225.9082 C 155.83763 225.43412 158 222.97142 158 220.00195 A 1 1 0 0 1 158 220 A 1 1 0 0 0 157 219 A 1 1 0 0 0 156 220 A 1 1 0 0 1 156 220.00195 C 156 222.23536 154.23341 224.00195 152 224.00195 C 149.76658 224.00195 148 222.23536 148 220.00195 A 1 1 0 0 1 148 220 A 1 1 0 0 0 147 219 z "
          style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#4c5263;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none" />
-    </g>
-    <g
-       inkscape:label="audio-volume-medium"
-       transform="translate(119.9998,-121.99833)"
-       id="g6016">
-      <rect
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:1;marker:none"
-         id="rect6019"
-         width="16"
-         height="16"
-         x="265.0004"
-         y="-413"
-         inkscape:label="audio-volume-high" />
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3022-8"
-         d="m 279.0004,-412.00167 -1.71289,1.0293 c 0.93437,1.55547 1.71307,4.15617 1.71289,5.9707 1.8e-4,1.81453 -0.77852,4.41523 -1.71289,5.9707 l 1.71289,1.0293 c 1.12166,-1.86618 1.9996,-4.82268 2,-7 -4e-4,-2.17732 -0.87834,-5.13382 -2,-7 z"
-         style="display:inline;opacity:0.35;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new" />
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3027-7"
-         d="m 275.7504,-410.50167 -1.71484,1.0293 c 0.6543,1.08883 0.96483,3.2004 0.96484,4.4707 -1e-5,1.2703 -0.31054,3.38187 -0.96484,4.4707 l 1.71484,1.0293 c 0.84091,-1.39973 1.25,-3.8671 1.25,-5.5 0,-1.6329 -0.40909,-4.10027 -1.25,-5.5 z"
-         style="display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new" />
-      <path
-         sodipodi:nodetypes="ccccsssssss"
-         inkscape:connector-curvature="0"
-         id="rect2976-7"
-         d="m 273.0004,-413.00167 -7,8 7,8 z m -5,5 c 0,-0.554 -0.446,-1 -1,-1 -0.554,0 -1,0.446 -1,1 v 6 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 z"
-         style="display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new" />
     </g>
     <g
        transform="translate(-99.99684,-239.99499)"
@@ -3745,37 +3600,32 @@
          id="path6162" />
     </g>
     <g
-       transform="translate(80.0454,-122.04399)"
-       id="g5071-3"
-       inkscape:label="audio-volume-high"
-       style="display:inline;enable-background:new">
+       style="display:inline;filter:url(#filter7554);enable-background:new"
+       transform="translate(79.9998,-122.00001)"
+       id="g3169-3"
+       inkscape:label="audio-volume-high">
       <rect
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
-         id="rect5073-6"
-         width="15.999996"
-         height="16.000013"
-         x="264.9548"
-         y="-412.95602" />
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect3160-6"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
       <path
-         sodipodi:nodetypes="cccccssssssc"
-         inkscape:connector-curvature="0"
-         id="rect2976-75"
-         transform="translate(160.9548,-604.95601)"
-         d="m 112,192 -7,8 7,8 z m -5,8 v -3 c 0,-0.554 -0.446,-1 -1,-1 -0.554,0 -1,0.446 -1,1 v 6 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 z"
-         style="opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549" />
+         id="rect6148-7"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
       <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3022-3"
-         transform="translate(160.9548,-604.95601)"
-         d="m 118,193 -1.71289,1.0293 c 0.93437,1.55547 1.71307,4.15617 1.71289,5.9707 1.8e-4,1.81453 -0.77852,4.41523 -1.71289,5.9707 L 118,207 c 1.12166,-1.86618 1.9996,-4.82268 2,-7 -4e-4,-2.17732 -0.87834,-5.13382 -2,-7 z"
-         style="opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549" />
+         id="rect6998-5"
+         style="opacity:1;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
       <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3027-5"
-         d="m 275.7048,-410.45601 -1.71484,1.0293 c 0.6543,1.08883 0.96483,3.2004 0.96484,4.4707 -10e-6,1.2703 -0.31054,3.38187 -0.96484,4.4707 l 1.71484,1.0293 c 0.84091,-1.39973 1.25,-3.8671 1.25,-5.5 0,-1.6329 -0.40909,-4.10027 -1.25,-5.5 z"
-         style="opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549" />
+         id="rect7003-3"
+         style="opacity:1;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
     </g>
     <g
        transform="translate(-200,-100)"
@@ -4430,6 +4280,128 @@
          d="M 152 176 L 149.59961 180 L 154.40039 180 L 155 179 L 152 179 L 152 176 z M 154.40039 180 L 152 184 L 152 181 L 149 181 L 149.59961 180 L 149 180 C 147.892 180 147 180.892 147 182 L 147 185 C 147 186.108 147.892 187 149 187 L 155 187 C 156.108 187 157 186.108 157 185 L 157 182 C 157 180.892 156.108 180 155 180 L 154.40039 180 z "
          transform="translate(121.00018,-563.00146)" />
     </g>
+    <g
+       style="display:inline;filter:url(#filter7554);enable-background:new"
+       transform="translate(99.9998,-122.00001)"
+       id="g5881"
+       inkscape:label="audio-volume-overamplified">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect5870"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path5872"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path5876"
+         style="opacity:1;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path5878"
+         style="opacity:1;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path14444"
+         style="opacity:0.35;fill:#4c5263;stroke-width:0.954314"
+         d="m 274.0004,-410.99999 h 2 v 12 h -2 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path14446"
+         style="opacity:0.35;fill:#4c5263"
+         d="m 278.0004,-412.99999 h 2 v 16 h -2 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;filter:url(#filter7554);enable-background:new"
+       transform="translate(119.9998,-122.00001)"
+       id="g5891"
+       inkscape:label="audio-volume-medium">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect5883"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path5885"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path5887"
+         style="opacity:1;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path5889"
+         style="opacity:0.35;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;filter:url(#filter7554);enable-background:new"
+       transform="translate(139.9998,-122.00001)"
+       id="g5903"
+       inkscape:label="audio-volume-low">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect5894"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path5896"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path5898"
+         style="opacity:0.35;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path5900"
+         style="opacity:0.35;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="display:inline;filter:url(#filter7554);enable-background:new"
+       transform="translate(159.9998,-122.00001)"
+       id="g5913"
+       inkscape:label="audio-volume-muted">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect5905"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path5907"
+         style="opacity:0.35;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path5909"
+         style="opacity:0.35;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path5911"
+         style="opacity:0.35;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
+    </g>
   </g>
   <g
      style="display:inline;filter:url(#filter7554)"
@@ -4437,37 +4409,6 @@
      inkscape:label="devices"
      id="layer10"
      inkscape:groupmode="layer">
-    <g
-       style="display:inline;enable-background:new"
-       transform="translate(179.9998,218)"
-       id="g5071-9"
-       inkscape:label="audio-speakers">
-      <rect
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:none;stroke-width:1;marker:none"
-         id="rect5073-4"
-         width="16"
-         height="16"
-         x="265.0004"
-         y="-413" />
-      <path
-         sodipodi:nodetypes="cccccssssssc"
-         inkscape:connector-curvature="0"
-         id="rect2976-75-3"
-         d="m 272.0004,-413 -7,8 7,8 z m -5,8 v -3 c 0,-0.554 -0.446,-1 -1,-1 -0.554,0 -1,0.446 -1,1 v 6 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 z"
-         style="display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new" />
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3022-3-6"
-         d="m 278.0004,-412 -1.71289,1.0293 c 0.93437,1.55547 1.71307,4.15617 1.71289,5.9707 1.8e-4,1.81453 -0.77852,4.41523 -1.71289,5.9707 L 278.0004,-398 c 1.12166,-1.86618 1.9996,-4.82268 2,-7 -4e-4,-2.17732 -0.87834,-5.13382 -2,-7 z"
-         style="display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new" />
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path3027-5-7"
-         d="m 274.7504,-410.5 -1.71484,1.0293 c 0.6543,1.08883 0.96483,3.2004 0.96484,4.4707 -1e-5,1.2703 -0.31054,3.38187 -0.96484,4.4707 l 1.71484,1.0293 c 0.84091,-1.39973 1.25,-3.8671 1.25,-5.5 0,-1.6329 -0.40909,-4.10027 -1.25,-5.5 z"
-         style="display:inline;opacity:1;vector-effect:none;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.31372549;enable-background:new" />
-    </g>
     <g
        style="display:inline;enable-background:new"
        transform="matrix(-1,0,0,1,682.0006,67.99664)"
@@ -6109,7 +6050,7 @@
          x="381.0004"
          height="16"
          width="16"
-         id="rect3160"
+         id="rect982"
          style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#4c5263;stroke:none;stroke-width:2;marker:none;enable-background:accumulate;fill-opacity:1;opacity:0.01" />
       <rect
          y="-302.99994"
@@ -6125,6 +6066,34 @@
          id="path3164"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="sccscccsscccccccccccc" />
+    </g>
+    <g
+       style="display:inline;opacity:1;enable-background:new"
+       transform="translate(179.9998,218)"
+       id="g3270"
+       inkscape:label="audio-speakers">
+      <rect
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.01;fill:#4c5263;fill-opacity:1;stroke:none;stroke-width:1;marker:none"
+         id="rect3262"
+         width="16"
+         height="16"
+         x="265.0004"
+         y="-413" />
+      <path
+         id="path3264"
+         style="opacity:1;fill:#4c5263;fill-opacity:1"
+         d="m 151.07031,554.04883 c -0.20813,0.008 -0.41406,0.0784 -0.57031,0.20117 L 147,557 h -1 -1 c -0.554,0 -1,0.446 -1,1 v 4 c 0,0.554 0.446,1 1,1 h 1 1 l 3.5,2.75 C 151,566.14286 152,566 152,565 v -5 -5 c 0,-0.6875 -0.4718,-0.96949 -0.92969,-0.95117 z"
+         transform="translate(121.0004,-965)" />
+      <path
+         id="path3266"
+         style="opacity:1;fill:#4c5263"
+         d="m 274.0004,-407.375 1.99999,-0.625 c 1.00001,2 1.00001,4 0,6 l -1.99999,-0.625 c 1,-2 1,-2.75 0,-4.75 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path3268"
+         style="opacity:1;fill:#4c5263"
+         d="m 277.0004,-409.0625 2,-0.9375 c 2,3 2,7 0,10 l -2,-0.9375 c 2,-3 2,-5.125 0,-8.125 z"
+         sodipodi:nodetypes="ccccc" />
     </g>
   </g>
   <g


### PR DESCRIPTION
Synchronizes the new Surround Speaker symbolic icons to the other
speaker-metaphor icons in the theme. This ensures we don't have
weird mismatches in our use of metaphors, plus the new icons have
more of a "Pop" feel (rounded corners, bubbly). Also reworks the
overamplified metaphor.

Fixes #43