### PR TITLE
fix(index): remove extra inherits

### DIFF
--- a/Pop/index.theme
+++ b/Pop/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Pop
 Comment=A simple and modern icon theme.
-Inherits=Pop-Extra,pop-os-branding,Adwaita,breeze,elementary,hicolor
+Inherits=Pop-Extra,pop-os-branding,Adwaita,hicolor
 #Example=folder
 
 # KDE/Plasma Stuff

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/system76/pop-icon-theme
 
 Package: pop-icon-theme
 Architecture: all
-Depends: ${misc:Depends}, gnome-icon-theme
+Depends: ${misc:Depends}, adwaita-icon-theme-full, hicolor-icon-theme
 Suggests: pop-icon-theme-extra
 Conflicts: system76-pop-icon-theme
 Description: Pop Icons


### PR DESCRIPTION
Removes some of our 3rd-party inherits. These seem to cause issues and it would be better if they weren't being inherited. We keep Adwaita because it mostly matches our aesthetics, and it's good to keep them as a fallback.

Also adjusts the depends to depend on the (modern) `adwaita-icon-theme-full` package instead of the (outdated) `gnome-icon-theme` package. 

Fixes #94